### PR TITLE
feat: change crawling algorithm

### DIFF
--- a/src/notice/notice.repository.ts
+++ b/src/notice/notice.repository.ts
@@ -112,6 +112,16 @@ export class NoticeRepository {
                 },
               },
             },
+            {
+              cralws: {
+                some: {
+                  OR: [
+                    { title: { contains: search } },
+                    { body: { contains: search } },
+                  ],
+                },
+              },
+            },
             { tags: { some: { name: { contains: search } } } },
           ],
         },
@@ -119,15 +129,9 @@ export class NoticeRepository {
           tags: true,
           contents: { where: { id: 1 } },
           author: { select: { name: true, uuid: true } },
-          files: {
-            where: { type: FileType.IMAGE },
-            orderBy: { order: 'asc' },
-          },
-          reactions: {
-            where: {
-              deletedAt: null,
-            },
-          },
+          files: { where: { type: FileType.IMAGE }, orderBy: { order: 'asc' } },
+          reactions: { where: { deletedAt: null } },
+          cralws: { take: 1, orderBy: { crawledAt: 'desc' } },
         },
       })
       .catch((err) => {
@@ -148,6 +152,7 @@ export class NoticeRepository {
               id: 'asc',
             },
           },
+          cralws: { take: 1, orderBy: { crawledAt: 'desc' } },
           reminders: true,
           author: {
             select: {
@@ -179,31 +184,15 @@ export class NoticeRepository {
     return this.prismaService.notice
       .update({
         where: { id, deletedAt: null },
-        data: {
-          views: {
-            increment: 1,
-          },
-        },
+        data: { views: { increment: 1 } },
         include: {
           tags: true,
-          contents: {
-            orderBy: {
-              id: 'asc',
-            },
-          },
+          contents: { orderBy: { id: 'asc' } },
+          cralws: { take: 1, orderBy: { crawledAt: 'desc' } },
           reminders: true,
-          author: {
-            select: {
-              name: true,
-              uuid: true,
-            },
-          },
+          author: { select: { name: true, uuid: true } },
           files: { orderBy: { order: 'asc' } },
-          reactions: {
-            where: {
-              deletedAt: null,
-            },
-          },
+          reactions: { where: { deletedAt: null } },
         },
       })
       .catch((err) => {

--- a/src/notice/notice.repository.ts
+++ b/src/notice/notice.repository.ts
@@ -605,15 +605,7 @@ export class NoticeRepository {
       .create({
         data: {
           author: { connect: { uuid: userUuid } },
-          cralws: {
-            create: {
-              id: 1,
-              title,
-              body,
-              type: 'ACADEMIC',
-              url,
-            },
-          },
+          cralws: { create: { id: 1, title, body, type: 'ACADEMIC', url } },
           tags: { connect: tags },
           files: {
             create: images.map((image, idx) => ({

--- a/src/notice/notice.repository.ts
+++ b/src/notice/notice.repository.ts
@@ -112,16 +112,6 @@ export class NoticeRepository {
                 },
               },
             },
-            {
-              cralws: {
-                some: {
-                  OR: [
-                    { title: { contains: search } },
-                    { body: { contains: search } },
-                  ],
-                },
-              },
-            },
             { tags: { some: { name: { contains: search } } } },
           ],
         },
@@ -129,9 +119,15 @@ export class NoticeRepository {
           tags: true,
           contents: { where: { id: 1 } },
           author: { select: { name: true, uuid: true } },
-          files: { where: { type: FileType.IMAGE }, orderBy: { order: 'asc' } },
-          reactions: { where: { deletedAt: null } },
-          cralws: { take: 1, orderBy: { crawledAt: 'desc' } },
+          files: {
+            where: { type: FileType.IMAGE },
+            orderBy: { order: 'asc' },
+          },
+          reactions: {
+            where: {
+              deletedAt: null,
+            },
+          },
         },
       })
       .catch((err) => {
@@ -152,7 +148,6 @@ export class NoticeRepository {
               id: 'asc',
             },
           },
-          cralws: { take: 1, orderBy: { crawledAt: 'desc' } },
           reminders: true,
           author: {
             select: {
@@ -184,15 +179,31 @@ export class NoticeRepository {
     return this.prismaService.notice
       .update({
         where: { id, deletedAt: null },
-        data: { views: { increment: 1 } },
+        data: {
+          views: {
+            increment: 1,
+          },
+        },
         include: {
           tags: true,
-          contents: { orderBy: { id: 'asc' } },
-          cralws: { take: 1, orderBy: { crawledAt: 'desc' } },
+          contents: {
+            orderBy: {
+              id: 'asc',
+            },
+          },
           reminders: true,
-          author: { select: { name: true, uuid: true } },
+          author: {
+            select: {
+              name: true,
+              uuid: true,
+            },
+          },
           files: { orderBy: { order: 'asc' } },
-          reactions: { where: { deletedAt: null } },
+          reactions: {
+            where: {
+              deletedAt: null,
+            },
+          },
         },
       })
       .catch((err) => {

--- a/src/notice/notice.repository.ts
+++ b/src/notice/notice.repository.ts
@@ -589,6 +589,7 @@ export class NoticeRepository {
     body,
     tags,
     images,
+    documents,
     userUuid,
     url,
     createdAt,
@@ -597,6 +598,7 @@ export class NoticeRepository {
     body: string;
     tags: Tag[];
     images: string[];
+    documents: { href: string; name: string }[];
     userUuid: string;
     url: string;
     createdAt: Date;
@@ -612,13 +614,22 @@ export class NoticeRepository {
             updatedAt: createdAt,
             cralws: { create: { title, body, type: 'ACADEMIC', url } },
             files: {
+              deleteMany: { type: FileType.DOCUMENT },
               createMany: {
-                data: images.map((image, idx) => ({
-                  order: idx,
-                  name: title,
-                  type: FileType.IMAGE,
-                  url: image,
-                })),
+                data: [
+                  ...images.map((image, idx) => ({
+                    order: idx,
+                    name: title,
+                    type: FileType.IMAGE,
+                    url: image,
+                  })),
+                  ...documents.map((document, idx) => ({
+                    order: idx,
+                    name: document.name,
+                    type: FileType.DOCUMENT,
+                    url: document.href,
+                  })),
+                ],
               },
             },
           },
@@ -636,12 +647,22 @@ export class NoticeRepository {
           cralws: { create: { title, body, type: 'ACADEMIC', url } },
           tags: { connect: tags },
           files: {
-            create: images.map((image, idx) => ({
-              order: idx,
-              name: title,
-              type: FileType.IMAGE,
-              url: image,
-            })),
+            createMany: {
+              data: [
+                ...images.map((image, idx) => ({
+                  order: idx,
+                  name: title,
+                  type: FileType.IMAGE,
+                  url: image,
+                })),
+                ...documents.map((document, idx) => ({
+                  order: idx,
+                  name: document.name,
+                  type: FileType.DOCUMENT,
+                  url: document.href,
+                })),
+              ],
+            },
           },
           createdAt,
         },

--- a/src/notice/notice.service.ts
+++ b/src/notice/notice.service.ts
@@ -17,7 +17,6 @@ import {
   mergeMap,
   ObservedValueOf,
   range,
-  switchMap,
   take,
   throwError,
   timeout,
@@ -70,7 +69,7 @@ export class NoticeService {
         getAllNoticeQueryDto,
         userUuid,
       ),
-      list: notices.map(({ files, author, cralws, ...notice }) => {
+      list: notices.map(({ files, author, ...notice }) => {
         delete notice.authorId;
         const images = files?.filter(({ type }) => type === FileType.IMAGE);
         const documents = files?.filter(
@@ -87,7 +86,6 @@ export class NoticeService {
           author: author.name,
           imagesUrl: images?.map((file) => `${this.s3Url}${file.url}`),
           documentsUrl: documents?.map((file) => `${this.s3Url}${file.url}`),
-          crawl: cralws[0],
         };
       }),
     };
@@ -100,7 +98,7 @@ export class NoticeService {
     } else {
       notice = await this.noticeRepository.getNotice(id);
     }
-    const { reminders, files, cralws, ...noticeInfo } = notice;
+    const { reminders, files, ...noticeInfo } = notice;
     const images = files?.filter(({ type }) => type === FileType.IMAGE);
     const documents = files?.filter(({ type }) => type === FileType.DOCUMENT);
     return {
@@ -109,7 +107,6 @@ export class NoticeService {
       imagesUrl: images?.map((file) => `${this.s3Url}${file.url}`),
       documentsUrl: documents?.map((file) => `${this.s3Url}${file.url}`),
       reminder: reminders.some((reminder) => reminder.uuid === userUuid),
-      crawl: cralws[0],
     };
   }
 

--- a/src/notice/notice.service.ts
+++ b/src/notice/notice.service.ts
@@ -371,6 +371,7 @@ export class NoticeService {
           title: meta.title,
           body: notice.content,
           images,
+          documents: notice.files,
           tags,
           userUuid: user.uuid,
           createdAt: dayjs(meta.createdAt)

--- a/src/notice/notice.service.ts
+++ b/src/notice/notice.service.ts
@@ -65,7 +65,7 @@ export class NoticeService {
         getAllNoticeQueryDto,
         userUuid,
       ),
-      list: notices.map(({ files, author, ...notice }) => {
+      list: notices.map(({ files, author, cralws, ...notice }) => {
         delete notice.authorId;
         const images = files?.filter(({ type }) => type === FileType.IMAGE);
         const documents = files?.filter(
@@ -82,6 +82,7 @@ export class NoticeService {
           author: author.name,
           imagesUrl: images?.map((file) => `${this.s3Url}${file.url}`),
           documentsUrl: documents?.map((file) => `${this.s3Url}${file.url}`),
+          crawl: cralws[0],
         };
       }),
     };
@@ -94,7 +95,7 @@ export class NoticeService {
     } else {
       notice = await this.noticeRepository.getNotice(id);
     }
-    const { reminders, files, ...noticeInfo } = notice;
+    const { reminders, files, cralws, ...noticeInfo } = notice;
     const images = files?.filter(({ type }) => type === FileType.IMAGE);
     const documents = files?.filter(({ type }) => type === FileType.DOCUMENT);
     return {
@@ -103,6 +104,7 @@ export class NoticeService {
       imagesUrl: images?.map((file) => `${this.s3Url}${file.url}`),
       documentsUrl: documents?.map((file) => `${this.s3Url}${file.url}`),
       reminder: reminders.some((reminder) => reminder.uuid === userUuid),
+      crawl: cralws[0],
     };
   }
 

--- a/src/notice/notice.service.ts
+++ b/src/notice/notice.service.ts
@@ -14,7 +14,6 @@ import {
   identity,
   lastValueFrom,
   map,
-  mergeMap,
   ObservedValueOf,
   range,
   take,
@@ -339,11 +338,7 @@ export class NoticeService {
         if (prev.cralws[0].body !== notice.content) return true;
         return false;
       }),
-      map(({ notice }) => notice),
-      mergeMap(async (notice) => {
-        return notice;
-      }),
-      concatMap(async ({ notice, meta }) => {
+      concatMap(async ({ prev, notice: { notice, meta } }) => {
         const tags = await this.tagService.findOrCreateTags([
           'academic',
           meta.category,
@@ -384,7 +379,7 @@ export class NoticeService {
             .toDate(),
           url: meta.link,
         });
-        await this.sendNoticeToAllUsers(meta.title, [], result);
+        if (!prev) await this.sendNoticeToAllUsers(meta.title, [], result);
       }),
     );
     await lastValueFrom($, { defaultValue: null });

--- a/src/notice/types/noticeFullcontent.ts
+++ b/src/notice/types/noticeFullcontent.ts
@@ -13,5 +13,6 @@ export type NoticeFullcontent = Prisma.NoticeGetPayload<{
     files: true;
     reactions: true;
     reminders: true;
+    cralws: true;
   };
 }>;

--- a/src/notice/types/noticeFullcontent.ts
+++ b/src/notice/types/noticeFullcontent.ts
@@ -13,6 +13,5 @@ export type NoticeFullcontent = Prisma.NoticeGetPayload<{
     files: true;
     reactions: true;
     reminders: true;
-    cralws: true;
   };
 }>;


### PR DESCRIPTION
close #14 
* 최근 100개의 공지 크롤링 (스테이징에서 테스트 후 간격이나 개수 변경 가능)
* 이미 올라간 공지는 title과 body가 다른지 확인 후 업데이트
  * fcm 알림은 보내지 않음
* 첨부파일 목록은 본문에 넣지 않고 DB에 기록 -> **가져와줄 때 S3 prefix 붙이지 않고 그대로 보여줘야 함** (아니면 첨부파일도 페치해서 s3에 올리기?)