### PR TITLE
publishedAt not null

### DIFF
--- a/prisma/migrations/20241112151511_published_at/migration.sql
+++ b/prisma/migrations/20241112151511_published_at/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Made the column `published_at` on table `notice` required. This step will fail if there are existing NULL values in that column.
+
+*/
+-- AlterTable
+ALTER TABLE "notice" ALTER COLUMN "published_at" SET NOT NULL;


### PR DESCRIPTION
publishedAt not null

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
	- `notice` 테이블의 `published_at` 열을 필수 필드로 변경하여 NULL 값을 허용하지 않도록 수정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->