### PR TITLE
groupId로 notice 조회 api 추가 및 ziggle-groups 관련 버그 수정

### DIFF
--- a/libs/infoteam-idp/src/infoteam-idp.service.ts
+++ b/libs/infoteam-idp/src/infoteam-idp.service.ts
@@ -36,7 +36,6 @@ export class InfoteamIdpService {
     code: string,
     redirectUri: string,
   ): Promise<IdpJwtResponse> {
-    this.logger.log('getAccessToken called');
     const accessTokenResponse = await firstValueFrom(
       this.httpService
         .post<IdpJwtResponse>(
@@ -67,7 +66,6 @@ export class InfoteamIdpService {
           }),
         ),
     );
-    this.logger.log('getAccessToken response');
     return accessTokenResponse.data;
   }
 
@@ -79,7 +77,6 @@ export class InfoteamIdpService {
    * @throws InternalServerErrorException if there is an unknown error while getting the user info
    */
   async getUserInfo(accessToken: string): Promise<UserInfo> {
-    this.logger.log('getUserInfo called');
     const userInfoResponse = await firstValueFrom(
       this.httpService
         .get<IdpUserInfoResponse>(this.idpUrl + '/userinfo', {
@@ -93,12 +90,10 @@ export class InfoteamIdpService {
               this.logger.debug('Invalid access token');
               throw new UnauthorizedException();
             }
-            this.logger.error(error.message);
             throw new InternalServerErrorException();
           }),
         ),
     );
-    this.logger.log('getUserInfo response');
     const {
       uuid,
       name,
@@ -117,7 +112,6 @@ export class InfoteamIdpService {
    * @throws InternalServerErrorException if there is an unknown error while refreshing the token
    */
   async refresh(refreshToken: string): Promise<IdpJwtResponse> {
-    this.logger.log('refresh called');
     const accessTokenResponse = await firstValueFrom(
       this.httpService
         .post<IdpJwtResponse>(
@@ -147,7 +141,6 @@ export class InfoteamIdpService {
           }),
         ),
     );
-    this.logger.log('refresh response');
     return accessTokenResponse.data;
   }
 
@@ -158,7 +151,6 @@ export class InfoteamIdpService {
    * @throws InternalServerErrorException if there is an unknown error while revoking the token
    */
   async revoke(token: string): Promise<void> {
-    this.logger.log('revoke called');
     await firstValueFrom(
       this.httpService
         .post(
@@ -187,6 +179,5 @@ export class InfoteamIdpService {
           }),
         ),
     );
-    this.logger.log('revoke response');
   }
 }

--- a/libs/infoteam-idp/src/infoteam-idp.service.ts
+++ b/libs/infoteam-idp/src/infoteam-idp.service.ts
@@ -90,6 +90,7 @@ export class InfoteamIdpService {
               this.logger.debug('Invalid access token');
               throw new UnauthorizedException();
             }
+            this.logger.error(error.message);
             throw new InternalServerErrorException();
           }),
         ),

--- a/prisma/migrations/20241116144114_add_group_id/migration.sql
+++ b/prisma/migrations/20241116144114_add_group_id/migration.sql
@@ -1,0 +1,22 @@
+/*
+  Warnings:
+
+  - The primary key for the `group` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - You are about to drop the column `group_name` on the `notice` table. All the data in the column will be lost.
+  - Added the required column `uuid` to the `group` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- DropForeignKey
+ALTER TABLE "notice" DROP CONSTRAINT "notice_group_name_fkey";
+
+-- AlterTable
+ALTER TABLE "group" DROP CONSTRAINT "group_pkey",
+ADD COLUMN     "uuid" UUID NOT NULL,
+ADD CONSTRAINT "group_pkey" PRIMARY KEY ("uuid");
+
+-- AlterTable
+ALTER TABLE "notice" DROP COLUMN "group_name",
+ADD COLUMN     "group_id" UUID;
+
+-- AddForeignKey
+ALTER TABLE "notice" ADD CONSTRAINT "notice_group_id_fkey" FOREIGN KEY ("group_id") REFERENCES "group"("uuid") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -53,7 +53,8 @@ model UserRecord {
 }
 
 model Group {
-  name String @id
+  uuid String @id @db.Uuid
+  name String
 
   Notice Notice[]
 
@@ -133,8 +134,8 @@ model Notice {
   crawls     Crawl[]
   tags       Tag[]
   reactions  Reaction[]
-  group      Group?       @relation(fields: [groupName], references: [name])
-  groupName  String?      @map("group_name")
+  group      Group?       @relation(fields: [groupId], references: [uuid])
+  groupId    String?      @map("group_id") @db.Uuid
   UserRecord UserRecord[]
 
   @@map("notice")

--- a/src/ai/ai.service.ts
+++ b/src/ai/ai.service.ts
@@ -85,14 +85,12 @@ export class AiService {
     text,
     targetLang,
   }: TranslateDto): Promise<TranslateResDto> {
-    this.logger.log(`translate called`);
     const result = await this.translator
       .translateText(text, null, targetLang)
       .catch((error) => {
         this.logger.error(`deepl translation error: ${error.message}`);
         throw new InternalServerErrorException(error.message);
       });
-    this.logger.log(`translate finished`);
     return {
       text: result.text,
       lang: targetLang,

--- a/src/group/group.controller.ts
+++ b/src/group/group.controller.ts
@@ -4,6 +4,7 @@ import { IdPGuard } from 'src/user/guard/idp.guard';
 import {
   ApiCreatedResponse,
   ApiInternalServerErrorResponse,
+  ApiOAuth2,
   ApiOperation,
   ApiTags,
   ApiUnauthorizedResponse,
@@ -12,6 +13,7 @@ import { GetToken } from 'src/user/decorator/get-token.decorator';
 import { GroupsTokenRes } from './dto/res/GroupsTokenRes.dto';
 
 @ApiTags('Group')
+@ApiOAuth2(['email', 'profile', 'openid'], 'oauth2')
 @Controller('group')
 export class GroupController {
   constructor(private readonly groupService: GroupService) {}

--- a/src/group/group.service.ts
+++ b/src/group/group.service.ts
@@ -68,11 +68,14 @@ export class GroupService {
   async getGroupInfoFromGroups(groupsToken: string): Promise<GroupInfo[]> {
     this.logger.log('getGroupInfoFromGroups called');
     const groupResponse = await firstValueFrom(
-      this.httpService.get<{ list: GroupInfo[] }>(this.groupsUrl + '/info', {
-        headers: {
-          Authorization: `Bearer ${groupsToken}`,
+      this.httpService.get<{ list: GroupInfo[] }>(
+        this.groupsUrl + '/external/info',
+        {
+          headers: {
+            Authorization: `Bearer ${groupsToken}`,
+          },
         },
-      }),
+      ),
     ).catch((error) => {
       if (error instanceof AxiosError) {
         if (error.response?.status === 401) {

--- a/src/notice/dto/req/createNotice.dto.ts
+++ b/src/notice/dto/req/createNotice.dto.ts
@@ -1,4 +1,4 @@
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Category } from '@prisma/client';
 import { Type } from 'class-transformer';
 import {
@@ -31,7 +31,7 @@ export class CreateNoticeDto {
   @MaxLength(100000)
   body: string;
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     example: '2021-08-01T00:00:00.000Z',
     description: '마감일',
     required: false,
@@ -41,7 +41,7 @@ export class CreateNoticeDto {
   @IsOptional()
   deadline?: Date;
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     example: '1',
     description: '공지태그의 id',
     required: false,
@@ -50,7 +50,7 @@ export class CreateNoticeDto {
   @IsOptional()
   tags: number[] = [];
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     description: '공지 그룹의 id',
     required: false,
     enum: Category,
@@ -59,7 +59,7 @@ export class CreateNoticeDto {
   @IsOptional()
   category?: Category;
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     example: 'wow.png',
     description: '이미지 파일 이름',
     required: false,
@@ -68,7 +68,7 @@ export class CreateNoticeDto {
   @IsOptional()
   images: string[] = [];
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     example: 'wow.docx',
     description: '파일 이름',
     required: false,
@@ -77,7 +77,7 @@ export class CreateNoticeDto {
   @IsOptional()
   documents: string[] = [];
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     example: '공지 그룹 id',
     description: '공지 그룹 id',
     required: false,

--- a/src/notice/dto/req/createNotice.dto.ts
+++ b/src/notice/dto/req/createNotice.dto.ts
@@ -78,11 +78,11 @@ export class CreateNoticeDto {
   documents: string[] = [];
 
   @ApiProperty({
-    example: '공지 그룹 이름',
-    description: '공지 그룹 이름',
+    example: '공지 그룹 id',
+    description: '공지 그룹 id',
     required: false,
   })
   @IsString()
   @IsOptional()
-  groupName?: string;
+  groupId?: string;
 }

--- a/src/notice/dto/req/getGroupNotice.dto.ts
+++ b/src/notice/dto/req/getGroupNotice.dto.ts
@@ -1,9 +1,9 @@
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiPropertyOptional } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 import { IsEnum, IsNumber, IsOptional, IsString } from 'class-validator';
 
 export class GetGroupNoticeQueryDto {
-  @ApiProperty({
+  @ApiPropertyOptional({
     example: '0',
     description: '넘길 공지의 개수',
     required: false,
@@ -13,7 +13,7 @@ export class GetGroupNoticeQueryDto {
   @IsOptional()
   offset?: number;
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     example: '10',
     description: '페이지당 공지 개수',
     required: false,
@@ -23,7 +23,7 @@ export class GetGroupNoticeQueryDto {
   @IsOptional()
   limit?: number;
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     example: 'en',
     description: '언어',
     required: false,
@@ -32,7 +32,7 @@ export class GetGroupNoticeQueryDto {
   @IsOptional()
   lang?: string;
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     example: 'deadline',
     description: '정렬 기준 (deadline, hot, recent)',
     required: false,

--- a/src/notice/dto/req/getGroupNotice.dto.ts
+++ b/src/notice/dto/req/getGroupNotice.dto.ts
@@ -1,0 +1,44 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsEnum, IsNumber, IsOptional, IsString } from 'class-validator';
+
+export class GetGroupNoticeQueryDto {
+  @ApiProperty({
+    example: '0',
+    description: '넘길 공지의 개수',
+    required: false,
+  })
+  @Type(() => Number)
+  @IsNumber()
+  @IsOptional()
+  offset?: number;
+
+  @ApiProperty({
+    example: '10',
+    description: '페이지당 공지 개수',
+    required: false,
+  })
+  @Type(() => Number)
+  @IsNumber()
+  @IsOptional()
+  limit?: number;
+
+  @ApiProperty({
+    example: 'en',
+    description: '언어',
+    required: false,
+  })
+  @IsString()
+  @IsOptional()
+  lang?: string;
+
+  @ApiProperty({
+    example: 'deadline',
+    description: '정렬 기준 (deadline, hot, recent)',
+    required: false,
+  })
+  @IsString()
+  @IsEnum(['deadline', 'hot', 'recent'])
+  @IsOptional()
+  orderBy?: 'recent' | 'deadline' | 'hot';
+}

--- a/src/notice/dto/res/generalNotice.dto.ts
+++ b/src/notice/dto/res/generalNotice.dto.ts
@@ -16,7 +16,7 @@ export class GeneralNoticeDto {
   title: string;
 
   @ApiProperty()
-  groupName: string | null;
+  groupId: string | null;
 
   @ApiProperty()
   author: AuthorDto;

--- a/src/notice/notice.controller.ts
+++ b/src/notice/notice.controller.ts
@@ -37,6 +37,7 @@ import {
   UpdateNoticeQueryDto,
 } from './dto/req/updateNotice.dto';
 import { AdditionalNoticeDto } from './dto/req/additionalNotice.dto';
+import { GetGroupNoticeQueryDto } from './dto/req/getGroupNotice.dto';
 
 @ApiTags('notice')
 @ApiOAuth2(['email', 'profile', 'openid'], 'oauth2')
@@ -85,6 +86,31 @@ export class NoticeController {
     @GetUser() user?: User,
   ): Promise<ExpandedGeneralNoticeDto> {
     return this.noticeService.getNotice(id, query, user?.uuid);
+  }
+
+  @ApiOperation({
+    summary: 'Get group notice list',
+    description: 'Get group notice list',
+  })
+  @ApiOkResponse({
+    type: GeneralNoticeListDto,
+    description: 'Return group notice list',
+  })
+  @ApiUnauthorizedResponse({ description: 'Unauthorized' })
+  @ApiInternalServerErrorResponse({ description: 'Internal Server Error' })
+  @Get('group/:id')
+  @UseGuards(IdPOptionalGuard)
+  async getGroupNoticeList(
+    @Param('id') groupId: string,
+    @Query() query: GetGroupNoticeQueryDto,
+    @GetUser() user?: User,
+  ): Promise<GeneralNoticeListDto> {
+    const result = await this.noticeService.getGroupNoticeList(
+      groupId,
+      query,
+      user?.uuid,
+    );
+    return result;
   }
 
   @ApiOperation({

--- a/src/notice/notice.mapper.ts
+++ b/src/notice/notice.mapper.ts
@@ -30,7 +30,7 @@ export class NoticeMapper {
       currentDeadline,
       reminders,
       category,
-      groupName,
+      groupId,
       publishedAt,
     }: NoticeFullContent,
     langFromDto?: string,
@@ -89,7 +89,7 @@ export class NoticeMapper {
         isReacted: reactions.some(({ userId }) => userId === userUuid),
       })),
       publishedAt,
-      groupName,
+      groupId,
     };
   }
 

--- a/src/notice/notice.repository.ts
+++ b/src/notice/notice.repository.ts
@@ -462,9 +462,11 @@ export class NoticeRepository {
           },
           category,
           group:
-            groupName === undefined
+            groupId === undefined || groupName === undefined
               ? undefined
-              : { connect: { uuid: groupId, name: groupName } },
+              : {
+                  connect: { uuid: groupId },
+                },
           publishedAt,
         },
         include: {

--- a/src/notice/notice.repository.ts
+++ b/src/notice/notice.repository.ts
@@ -391,12 +391,12 @@ export class NoticeRepository {
       userUuid,
       publishedAt,
       createdAt,
-      groupName
+      groupName,
     }: {
       userUuid: string;
       publishedAt: Date;
       createdAt?: Date;
-      groupName?: string,
+      groupName?: string;
     },
   ): Promise<NoticeFullContent> {
     this.logger.log(`createNotice`);

--- a/src/notice/notice.repository.ts
+++ b/src/notice/notice.repository.ts
@@ -199,7 +199,6 @@ export class NoticeRepository {
     { offset = 0, limit = 10, orderBy }: GetGroupNoticeQueryDto,
     groupId: string,
   ): Promise<NoticeFullContent[]> {
-    this.logger.log(`getGroupNoticeList`);
     return this.prismaService.notice
       .findMany({
         take: limit,
@@ -399,8 +398,6 @@ export class NoticeRepository {
       groupName?: string;
     },
   ): Promise<NoticeFullContent> {
-    this.logger.log(`createNotice`);
-
     const findTags = await this.prismaService.tag.findMany({
       where: {
         id: {

--- a/src/notice/notice.service.ts
+++ b/src/notice/notice.service.ts
@@ -29,7 +29,6 @@ import { FcmService } from 'src/fcm/fcm.service';
 import { FcmTargetUser } from 'src/fcm/types/fcmTargetUser.type';
 import { htmlToText } from 'html-to-text';
 import { Notification } from 'firebase-admin/messaging';
-import { ConfigService } from '@nestjs/config';
 import { GetGroupNoticeQueryDto } from './dto/req/getGroupNotice.dto';
 import { Authority } from '../group/types/groupInfo.type';
 import { Loggable } from '@lib/logger/decorator/loggable';
@@ -183,7 +182,7 @@ export class NoticeService {
         userUuid,
         publishedAt: new Date(new Date().getTime() + this.fcmDelay),
         createdAt: undefined,
-        groupName
+        groupName,
       },
     );
 

--- a/src/tag/tag.repository.ts
+++ b/src/tag/tag.repository.ts
@@ -39,6 +39,7 @@ export class TagRepository {
             throw new NotFoundException(`tag with name ${name} not found`);
           }
         }
+        this.logger.error('findTag error');
         this.logger.debug(err);
         throw new InternalServerErrorException();
       })

--- a/src/tag/tag.repository.ts
+++ b/src/tag/tag.repository.ts
@@ -23,7 +23,6 @@ export class TagRepository {
         throw new InternalServerErrorException();
       })
       .then((tags) => {
-        this.logger.log('findAllTags: ' + tags.length);
         return tags;
       });
   }
@@ -40,12 +39,10 @@ export class TagRepository {
             throw new NotFoundException(`tag with name ${name} not found`);
           }
         }
-        this.logger.error('findTag error');
         this.logger.debug(err);
         throw new InternalServerErrorException();
       })
       .then((tag) => {
-        this.logger.log('findTag: ' + tag);
         return tag;
       });
   }
@@ -64,7 +61,6 @@ export class TagRepository {
         throw new InternalServerErrorException();
       })
       .then((tags) => {
-        this.logger.log('searchTags: ' + tags.length);
         return tags;
       });
   }
@@ -81,7 +77,6 @@ export class TagRepository {
         throw new InternalServerErrorException();
       })
       .then((tag) => {
-        this.logger.log('createTag: ' + tag);
         return tag;
       });
   }

--- a/src/user/user.repository.ts
+++ b/src/user/user.repository.ts
@@ -25,10 +25,8 @@ export class UserRepository {
       where: { uuid },
     });
     if (user) {
-      this.logger.log('user found');
       return user;
     }
-    this.logger.log('user not found, create new user');
     return this.prismaService.user.create({
       data: {
         uuid,
@@ -49,7 +47,6 @@ export class UserRepository {
       .catch((err) => {
         if (err instanceof PrismaClientKnownRequestError) {
           if (err.code === 'P2016') {
-            this.logger.debug('user not found');
             throw new NotFoundException();
           }
           this.logger.error(err.message);
@@ -59,10 +56,8 @@ export class UserRepository {
         throw new InternalServerErrorException();
       });
     if (user.name === name) {
-      this.logger.log('user name is same');
       return user;
     }
-    this.logger.log('user name is different, update user');
     return this.prismaService.user
       .update({
         where: { uuid },
@@ -81,7 +76,6 @@ export class UserRepository {
         throw new InternalServerErrorException();
       })
       .then((user) => {
-        this.logger.log('findUserAndUpdate finished');
         return user;
       });
   }
@@ -95,7 +89,6 @@ export class UserRepository {
       .catch((err) => {
         if (err instanceof PrismaClientKnownRequestError) {
           if (err.code === 'P2025' || err.code === 'P2016') {
-            this.logger.log('user not found');
             throw new NotFoundException();
           }
           this.logger.error(err.message);
@@ -105,7 +98,6 @@ export class UserRepository {
         throw new InternalServerErrorException();
       })
       .then((user) => {
-        this.logger.log('setConsent finished');
         return user;
       });
   }

--- a/src/user/user.repository.ts
+++ b/src/user/user.repository.ts
@@ -47,6 +47,7 @@ export class UserRepository {
       .catch((err) => {
         if (err instanceof PrismaClientKnownRequestError) {
           if (err.code === 'P2016') {
+            this.logger.debug('user not found');
             throw new NotFoundException();
           }
           this.logger.error(err.message);


### PR DESCRIPTION
# Pull request

## 개요
<!-- 어떤 이슈를 해결하였나요? -->
close #114 

## PR Checklist

- [ ] 환경에 따른 실행 여부를 확인하였나요?
- [ ] 변경 내용에 관한 테스트를 진행하였나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

- **신규 기능**
	- UUID를 사용하여 그룹을 식별하는 새로운 데이터베이스 구조 도입.
	- 특정 그룹에 대한 공지 목록을 검색하는 새로운 API 엔드포인트 추가.
	- 공지 생성 시 그룹 ID를 사용하도록 변경.
	- 그룹 공지를 검색하기 위한 새로운 DTO 클래스 추가.

- **버그 수정**
	- 공지 목록 검색 시 그룹 ID 필터링 기능 개선.

- **문서화**
	- API 문서에 OAuth2 보안 요구 사항 추가.
	- 새로운 DTO 클래스 및 API 속성 업데이트.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->