### PR TITLE
modify: change return type of notice alarm

### DIFF
--- a/src/notice/notice.controller.ts
+++ b/src/notice/notice.controller.ts
@@ -125,7 +125,7 @@ export class NoticeController {
   async sendNotice(
     @GetUser() user: User,
     @Param('id', ParseIntPipe) id: number,
-  ): Promise<void> {
+  ): Promise<ExpandedGeneralNoticeDto> {
     return this.noticeService.sendNotice(id, user.uuid);
   }
 

--- a/src/notice/notice.service.ts
+++ b/src/notice/notice.service.ts
@@ -164,7 +164,10 @@ export class NoticeService {
     return notice;
   }
 
-  async sendNotice(id: number, userUuid: string): Promise<void> {
+  async sendNotice(
+    id: number,
+    userUuid: string,
+  ): Promise<ExpandedGeneralNoticeDto> {
     const notice = await this.getNotice(id, { isViewed: false });
     if (notice.author.uuid !== userUuid) {
       throw new ForbiddenException('not author of the notice');
@@ -188,6 +191,8 @@ export class NoticeService {
       },
     );
     await this.noticeRepository.updatePublishedAt(id, new Date());
+
+    return notice;
   }
 
   async addNoticeAdditional(

--- a/src/notice/notice.service.ts
+++ b/src/notice/notice.service.ts
@@ -176,16 +176,6 @@ export class NoticeService {
       throw new ForbiddenException('a message already sent');
     }
 
-    await this.noticeRepository
-      .updatePublishedAt(id, new Date())
-      .catch((error) => {
-        this.logger.error(
-          `Failed to update publishedAt for notice ${id}: `,
-          error,
-        );
-        throw new InternalServerErrorException('failed to update publishedAt');
-      });
-
     const notification = {
       title: '[긴급] ' + notice.title,
       body: notice.content,
@@ -207,6 +197,16 @@ export class NoticeService {
           error,
         );
         throw new InternalServerErrorException('failed to send notification');
+      });
+
+    await this.noticeRepository
+      .updatePublishedAt(id, new Date())
+      .catch((error) => {
+        this.logger.error(
+          `Failed to update publishedAt for notice ${id}: `,
+          error,
+        );
+        throw new InternalServerErrorException('failed to update publishedAt');
       });
 
     return notice;


### PR DESCRIPTION
# Pull request

## 개요
push notification을 즉시 보내는 API가 notice 정보를 return 하도록 변경하였습니다.

## PR Checklist

- [x] 환경에 따른 실행 여부를 확인하였나요?
- [x] 변경 내용에 관한 테스트를 진행하였나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **새로운 기능**
	- `sendNotice` 메서드가 이제 공지 전송 후 공지 객체를 반환하도록 변경되었습니다.
	- 여러 메서드의 반환 타입이 통일되어 공지 객체를 반환합니다.

- **버그 수정**
	- 특정 예외 처리 개선으로 일관된 오류 응답 제공.

- **문서화**
	- API 문서의 응답 및 오류 처리에 대한 세부사항 유지.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->