### PR TITLE
[BUG] bin가 아닌 파일을 올릴때, 500 에러가 발생

### DIFF
--- a/src/image/image.service.ts
+++ b/src/image/image.service.ts
@@ -1,4 +1,9 @@
-import { Injectable, Logger } from '@nestjs/common';
+import {
+  BadRequestException,
+  Injectable,
+  InternalServerErrorException,
+  Logger,
+} from '@nestjs/common';
 import path from 'path';
 import { FileService } from 'src/file/file.service';
 import sharp from 'sharp';
@@ -72,7 +77,13 @@ export class ImageService {
     file.buffer = await sharp(file.buffer)
       .rotate()
       .webp({ effort: 0 })
-      .toBuffer();
+      .toBuffer()
+      .catch((error) => {
+        if (error.message.includes('unsupported image format')) {
+          throw new BadRequestException(error.message);
+        }
+        throw new InternalServerErrorException(error.message);
+      });
     return file;
   }
 }


### PR DESCRIPTION
# Pull request

## 개요
<!-- 어떤 이슈를 해결하였나요? -->

## PR Checklist

- [x] 환경에 따른 실행 여부를 확인하였나요?

- [x] 변경 내용에 관한 테스트를 진행하였나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
	- 이미지 변환 중 발생하는 오류에 대한 구체적인 예외 처리를 추가했습니다. 지원되지 않는 이미지 형식의 경우 `BadRequestException`을 발생시키고, 그 외의 오류는 `InternalServerErrorException`을 발생시킵니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->