### PR TITLE
create last_edited_at field and sort by that field

### DIFF
--- a/prisma/migrations/20241228153436_add_last_edited_at/data-migration.ts
+++ b/prisma/migrations/20241228153436_add_last_edited_at/data-migration.ts
@@ -1,0 +1,35 @@
+// This file is a data migration that updates the `lastEditedAt` field of all `Notice` records to the value of the `updatedAt` field.
+// To run this migration, use the following command:
+// npx ts-node ./prisma/migrations/20241228153436_add_last_edited_at/data-migration.ts
+
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+async function main() {
+  await prisma.$transaction(async (tx) => {
+    const notices = await tx.notice.findMany();
+    for (const notice of notices) {
+      await tx.notice.update({
+        where: { id: notice.id },
+        data: { lastEditedAt: notice.updatedAt, updatedAt: notice.updatedAt },
+      });
+      console.log(
+        `Updated notice ${notice.id} lastEditedAt to ${notice.updatedAt}`,
+      );
+    }
+  });
+}
+
+main()
+  .then(async () => {
+    console.log('Data migration completed successfully');
+    process.exit(0);
+  })
+  .catch(async (e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/prisma/migrations/20241228153436_add_last_edited_at/migration.sql
+++ b/prisma/migrations/20241228153436_add_last_edited_at/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "notice" ADD COLUMN     "last_edited_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -122,7 +122,8 @@ model Notice {
   category        Category  @default(ETC)
   currentDeadline DateTime? @map("current_deadline")
   createdAt       DateTime  @default(now()) @map("created_at")
-  updatedAt       DateTime  @default(now()) @map("updated_at") @updatedAt
+  updatedAt       DateTime  @default(now()) @updatedAt @map("updated_at")
+  lastEditedAt    DateTime  @default(now()) @map("last_edited_at")
   publishedAt     DateTime  @map("published_at")
   deletedAt       DateTime? @map("deleted_at")
 

--- a/src/notice/notice.repository.ts
+++ b/src/notice/notice.repository.ts
@@ -111,7 +111,7 @@ export class NoticeRepository {
         orderBy: {
           currentDeadline: orderBy === 'deadline' ? 'asc' : undefined,
           views: orderBy === 'hot' ? 'desc' : undefined,
-          updatedAt: orderBy === 'recent' ? 'desc' : undefined,
+          lastEditedAt: orderBy === 'recent' ? 'desc' : undefined,
         },
         where: {
           ...(orderBy === 'deadline'
@@ -206,7 +206,7 @@ export class NoticeRepository {
         orderBy: {
           currentDeadline: orderBy === 'deadline' ? 'asc' : undefined,
           views: orderBy === 'hot' ? 'desc' : undefined,
-          updatedAt: orderBy === 'recent' ? 'desc' : undefined,
+          lastEditedAt: orderBy === 'recent' ? 'desc' : undefined,
         },
         where: {
           ...(orderBy === 'deadline'
@@ -564,6 +564,7 @@ export class NoticeRepository {
             },
           },
           currentDeadline: deadline ?? notice.currentDeadline,
+          lastEditedAt: new Date(),
           updatedAt: new Date(),
         },
       })
@@ -598,6 +599,7 @@ export class NoticeRepository {
               deadline,
             },
           },
+          lastEditedAt: new Date(),
         },
       })
       .catch((error) => {
@@ -746,6 +748,7 @@ export class NoticeRepository {
             },
           },
           currentDeadline: deadline,
+          lastEditedAt: new Date(),
         },
       })
       .catch((error) => {


### PR DESCRIPTION
Fixes #144
주의 사항
-> 데이터 마이그래션을 위한 스크립트를 ts로 따로 만듬 따라서 데이터 마이그래이래이션을 할 때, 해당 스크립트를 실행해야함.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **데이터베이스 변경**
	- 공지사항 모델에 `lastEditedAt` 필드 추가
	- 공지사항의 최종 편집 시간을 추적하는 새로운 타임스탬프 도입

- **데이터 마이그레이션**
	- 기존 공지사항의 `lastEditedAt` 필드를 `updatedAt` 값으로 업데이트

- **기능 업데이트**
	- 공지사항 정렬 및 조회 로직을 `lastEditedAt` 기준으로 변경

<!-- end of auto-generated comment: release notes by coderabbit.ai -->