### PR TITLE
feat: add get groupResDto by group uuid api

### DIFF
--- a/apps/api/src/group/group.controller.ts
+++ b/apps/api/src/group/group.controller.ts
@@ -4,6 +4,7 @@ import {
   Headers,
   Post,
   Query,
+  Param,
   UseGuards,
 } from '@nestjs/common';
 import { GroupService } from './group.service';
@@ -18,7 +19,7 @@ import {
   ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
 import { GroupsTokenRes } from './dto/res/GroupsTokenRes.dto';
-import { GroupListResDto } from './dto/res/GroupsRes.dto';
+import { GroupListResDto, GroupResDto } from './dto/res/GroupsRes.dto';
 import { GetGroupByNameQueryDto } from './dto/req/getGroup.dto';
 import { IdPGuard } from '../user/guard/idp.guard';
 import { GetToken } from '../user/decorator/get-token.decorator';
@@ -84,5 +85,20 @@ export class GroupController {
     @Headers('Groups-Token') groupToken: string,
   ): Promise<GroupInfo[]> {
     return this.groupService.getGroupInfoFromGroups(groupToken);
+  }
+
+  @ApiOperation({
+    summary: 'Get group info by UUID',
+    description: 'Get detailed information about a specific group',
+  })
+  @ApiOkResponse({
+    type: GroupResDto,
+    description: '특정 그룹의 상세 정보',
+  })
+  @ApiUnauthorizedResponse()
+  @ApiInternalServerErrorResponse()
+  @Get(':uuid')
+  async getGroupByUuid(@Param('uuid') uuid: string): Promise<GroupInfo> {
+    return this.groupService.getGroupByUuid(uuid);
   }
 }


### PR DESCRIPTION
# Pull request

## 개요
<!-- 어떤 이슈를 해결하였나요? -->
그룹 uuid로 그룹 정보를 가져오는 api가 없어요
그래서 커서로 만들었습니다.

## PR Checklist

- [ ] 환경에 따른 실행 여부를 확인하였나요?
  - 아니요.
- [ ] 변경 내용에 관한 테스트를 진행하였나요?
  - 아니요.
  
백엔 개발환경 세팅이 되어있지 않습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
	- 고유 식별자(UUID)를 이용해 그룹의 상세 정보를 조회할 수 있는 API 엔드포인트가 추가되었습니다.
	- 요청 시 그룹 정보가 없을 경우, 명확한 오류 메시지로 피드백을 제공하도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->