### PR TITLE
Group의 notice list를 가져오는 API와 기존에 존재했던 notice list 조회 API 통합

### DIFF
--- a/apps/api/src/notice/dto/req/getAllNotice.dto.ts
+++ b/apps/api/src/notice/dto/req/getAllNotice.dto.ts
@@ -87,4 +87,13 @@ export class GetAllNoticeQueryDto {
   @IsEnum(['own', 'reminders'])
   @IsOptional()
   my?: 'own' | 'reminders';
+
+  @ApiProperty({
+    example: 'b5555555-0000-1111-2222-47997e666666',
+    description: '그룹 아이디',
+    required: false,
+  })
+  @IsString()
+  @IsOptional()
+  groupId?: string;
 }

--- a/apps/api/src/notice/dto/req/getAllNotice.dto.ts
+++ b/apps/api/src/notice/dto/req/getAllNotice.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Category } from '@prisma/client';
-import { Type } from 'class-transformer';
+import { Expose, Type } from 'class-transformer';
 import {
   IsArray,
   IsEnum,
@@ -62,10 +62,12 @@ export class GetAllNoticeQueryDto {
     example: 'deadline',
     description: '정렬 기준 (deadline, hot, recent)',
     required: false,
+    name: 'order-by',
   })
   @IsString()
   @IsEnum(['deadline', 'hot', 'recent'])
   @IsOptional()
+  @Expose({ name: 'order-by' })
   orderBy?: 'recent' | 'deadline' | 'hot';
 
   @ApiProperty({
@@ -92,8 +94,10 @@ export class GetAllNoticeQueryDto {
     example: 'b5555555-0000-1111-2222-47997e666666',
     description: '그룹 아이디',
     required: false,
+    name: 'group-id',
   })
   @IsString()
   @IsOptional()
+  @Expose({ name: 'group-id' })
   groupId?: string;
 }

--- a/apps/api/src/notice/notice.controller.ts
+++ b/apps/api/src/notice/notice.controller.ts
@@ -35,7 +35,6 @@ import {
   UpdateNoticeQueryDto,
 } from './dto/req/updateNotice.dto';
 import { AdditionalNoticeDto } from './dto/req/additionalNotice.dto';
-import { GetGroupNoticeQueryDto } from './dto/req/getGroupNotice.dto';
 import { IdPGuard, IdPOptionalGuard } from '../user/guard/idp.guard';
 import { GetUser } from '../user/decorator/get-user.decorator';
 
@@ -83,31 +82,6 @@ export class NoticeController {
     @GetUser() user?: User,
   ): Promise<ExpandedGeneralNoticeDto> {
     return this.noticeService.getNotice(id, query, user?.uuid);
-  }
-
-  @ApiOperation({
-    summary: 'Get group notice list',
-    description: 'Get group notice list',
-  })
-  @ApiOkResponse({
-    type: GeneralNoticeListDto,
-    description: 'Return group notice list',
-  })
-  @ApiUnauthorizedResponse({ description: 'Unauthorized' })
-  @ApiInternalServerErrorResponse({ description: 'Internal Server Error' })
-  @Get('group/:id')
-  @UseGuards(IdPOptionalGuard)
-  async getGroupNoticeList(
-    @Param('id') groupId: string,
-    @Query() query: GetGroupNoticeQueryDto,
-    @GetUser() user?: User,
-  ): Promise<GeneralNoticeListDto> {
-    const result = await this.noticeService.getGroupNoticeList(
-      groupId,
-      query,
-      user?.uuid,
-    );
-    return result;
   }
 
   @ApiOperation({

--- a/apps/api/src/notice/notice.service.ts
+++ b/apps/api/src/notice/notice.service.ts
@@ -23,7 +23,6 @@ import {
 } from './dto/req/updateNotice.dto';
 import { htmlToText } from 'html-to-text';
 import { Notification } from 'firebase-admin/messaging';
-import { GetGroupNoticeQueryDto } from './dto/req/getGroupNotice.dto';
 import { Authority } from '../group/types/groupInfo.type';
 import { Loggable } from '@lib/logger/decorator/loggable';
 import { CustomConfigService } from '@lib/custom-config';
@@ -76,40 +75,6 @@ export class NoticeService {
     return {
       total: await this.noticeRepository.getTotalCount(
         getAllNoticeQueryDto,
-        userUuid,
-      ),
-      list: await Promise.all(notices),
-    };
-  }
-
-  async getGroupNoticeList(
-    groupId: string,
-    getGroupNoticeQueryDto: GetGroupNoticeQueryDto,
-    userUuid?: string,
-  ): Promise<GeneralNoticeListDto> {
-    const notices = (
-      await this.noticeRepository.getGroupNoticeList(
-        getGroupNoticeQueryDto,
-        groupId,
-      )
-    ).map((notice) =>
-      this.noticeMapper
-        .NoticeFullContentToGeneralNoticeList(
-          notice,
-          getGroupNoticeQueryDto.lang,
-          userUuid,
-        )
-        .catch((error) => {
-          this.logger.debug(`Notice ${notice.id} is not valid`);
-          this.logger.error(error);
-          throw new InternalServerErrorException(
-            `Notice ${notice.id} is not valid`,
-          );
-        }),
-    );
-    return {
-      total: await this.noticeRepository.getTotalCount(
-        getGroupNoticeQueryDto,
         userUuid,
       ),
       list: await Promise.all(notices),


### PR DESCRIPTION
# Pull request

## 개요
<!-- 어떤 이슈를 해결하였나요? -->
Group의 notice list를 가져오는 API와 기존에 존재했던 notice list 조회 API 통합했습니다.
DTO에 group에 대한 정보를 추가하여, 하나의 API에서 group이 작성한 공지를 filtering 할 수 있도록 변경했습니다.

## PR Checklist

- [x] 환경에 따른 실행 여부를 확인하였나요?
- [x] 변경 내용에 관한 테스트를 진행하였나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - 공지사항 조회 시 데이터 응답의 키가 개선되어, "order-by"와 "group-id"와 같이 보다 명확한 쿼리 파라미터를 제공합니다.
- **Refactor**
  - 그룹별 공지사항 전용 조회 기능이 제거되어, 공지사항 조회 방식이 단일화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->