### PR TITLE
fix: add groupId in getTotalCount

### DIFF
--- a/apps/api/src/notice/notice.repository.ts
+++ b/apps/api/src/notice/notice.repository.ts
@@ -32,13 +32,14 @@ export class NoticeRepository {
    * @returns the total count of the notices
    */
   async getTotalCount(
-    { search, tags, orderBy, my, category }: GetAllNoticeQueryDto,
+    { search, tags, orderBy, my, category, groupId }: GetAllNoticeQueryDto,
     userUuid?: string,
   ): Promise<number> {
     return await this.prismaService.notice.count({
       where: {
         deletedAt: null,
         category,
+        groupId,
         authorId: my === 'own' ? userUuid : undefined,
         reminders:
           my === 'reminders' ? { some: { uuid: userUuid } } : undefined,


### PR DESCRIPTION
# Pull request

## 개요
<!-- 어떤 이슈를 해결하였나요? -->
notice list count를 query할 때 where문에 group 정보가 포함되지 않아 실제로 반환되는 notice list length와 count 정보가 일치하지 않는 문제를 해결했습니다.

## PR Checklist

- [x] 환경에 따른 실행 여부를 확인하였나요?
- [x] 변경 내용에 관한 테스트를 진행하였나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 알림 서비스에 그룹별 필터링 기능이 추가되었습니다. 이제 사용자는 특정 그룹에 속한 알림만 조회하고, 해당 그룹의 알림 개수를 확인할 수 있습니다. 이를 통해 각 그룹별 알림 관리가 보다 체계적이고 효율적으로 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->