### PR TITLE
fix: retry send notification when failed, log for queue job when job failed

### DIFF
--- a/apps/api/src/fcm/fcm.consumer.ts
+++ b/apps/api/src/fcm/fcm.consumer.ts
@@ -27,7 +27,7 @@ export class FcmConsumer {
   }
 
   @OnQueueRemoved()
-  async onRemoved(job: Job) {
-    this.logger.debug(`Job ${job.id} removed`);
+  async onRemoved(jobId: string) {
+    this.logger.debug(`Job ${jobId} removed`);
   }
 }

--- a/apps/api/src/fcm/fcm.consumer.ts
+++ b/apps/api/src/fcm/fcm.consumer.ts
@@ -1,5 +1,6 @@
 import {
   OnQueueCompleted,
+  OnQueueFailed,
   OnQueueRemoved,
   Process,
   Processor,
@@ -18,16 +19,23 @@ export class FcmConsumer {
   async handleFcmMessage(job: { data: QueueDataType }): Promise<void> {
     this.logger.debug('Start processing fcm message');
     const { targetUser, notification, data } = job.data;
+
     await this.fcmService.postMessage(notification, targetUser, data);
   }
 
+  @OnQueueFailed()
+  onFailed(job: Job, error: Error) {
+    this.logger.error(`Job ${job.id} failed with error: ${error}`);
+    this.logger.error(job.data);
+  }
+
   @OnQueueCompleted()
-  async onCompleted(job: Job) {
+  onCompleted(job: Job) {
     this.logger.debug(`Job ${job.id} completed`);
   }
 
   @OnQueueRemoved()
-  async onRemoved(jobId: string) {
+  onRemoved(jobId: string) {
     this.logger.debug(`Job ${jobId} removed`);
   }
 }

--- a/apps/api/src/fcm/fcm.repository.ts
+++ b/apps/api/src/fcm/fcm.repository.ts
@@ -14,10 +14,10 @@ export class FcmRepository {
   private readonly logger = new Logger(FcmRepository.name);
   constructor(private readonly prismaService: PrismaService) {}
 
-  async updateFcmtokensSuccess(fcmtokens: string[]): Promise<void> {
+  async updateFcmTokensSuccess(fcmTokens: string[]): Promise<void> {
     await this.prismaService.fcmToken.updateMany({
       where: {
-        fcmTokenId: { in: fcmtokens },
+        fcmTokenId: { in: fcmTokens },
       },
       data: {
         successCount: { increment: 1 },
@@ -25,10 +25,10 @@ export class FcmRepository {
     });
   }
 
-  async updateFcmtokensFail(fcmtokens: string[]): Promise<void> {
+  async updateFcmTokensFail(fcmTokens: string[]): Promise<void> {
     await this.prismaService.fcmToken.updateMany({
       where: {
-        fcmTokenId: { in: fcmtokens },
+        fcmTokenId: { in: fcmTokens },
       },
       data: {
         failCount: { increment: 1 },

--- a/apps/api/src/fcm/fcm.service.ts
+++ b/apps/api/src/fcm/fcm.service.ts
@@ -69,6 +69,7 @@ export class FcmService {
         ({ fcmTokenId }) => fcmTokenId,
       );
     }
+
     const batches = tokens.reduce((acc, token, index) => {
       if (index % 500 === 0) return [[token], ...acc];
       const [first, ...array] = acc;
@@ -77,12 +78,12 @@ export class FcmService {
 
     const results = await Promise.allSettled(
       batches.map(async (subTokens) => {
-        try {
-          return await this._postMessage(notification, subTokens, data);
-        } catch (error) {
-          this.logger.error(`Failed batch: ${error.message}`);
-          throw error;
-        }
+        await this._postMessage(notification, subTokens, data).catch(
+          (error) => {
+            this.logger.error('Error while sending notification: ', error);
+            throw error;
+          },
+        );
       }),
     );
 

--- a/apps/api/src/fcm/fcm.service.ts
+++ b/apps/api/src/fcm/fcm.service.ts
@@ -94,17 +94,19 @@ export class FcmService {
       .flat();
 
     if (failedTokens.length > 0) {
+      this.logger.warn('Some notifications permanently failed: ', failedTokens);
+    } else {
+      this.logger.debug('All notifications sent successfully');
+    }
+
+    if (failedTokens.length > 0) {
       this.logger.debug(
         `Retrying failed tokens (${failedTokens.length} tokens)`,
       );
       await new Promise((resolve) => setTimeout(resolve, 2000));
-      return this._postMessage(notification, failedTokens, data);
-    }
+      await this._postMessage(notification, failedTokens, data);
 
-    if (failedTokens.length > 0) {
-      this.logger.warn('Some notifications permanently failed: ', failedTokens);
-    } else {
-      this.logger.debug('All notifications sent successfully');
+      this.logger.debug('Retry completed');
     }
   }
 


### PR DESCRIPTION
# Pull request

## 개요
<!-- 어떤 이슈를 해결하였나요? -->

https://github.com/gsainfoteam/ziggle-be/issues/159
- fcm queue에서 작업이 삭제된 경우 어떠한 작업이 삭제된 것인지 jobId를 출력해야 합니다. onRemoved 함수에서 job object를 parameter로 받아오는 것이 아니라, jobId를 바로 받아오기 때문에, 이를 반영하여 수정했습니다.

https://github.com/gsainfoteam/ziggle-be/issues/164
- notification을 보내는 과정에서 몇몇 token에 대한 notification 전송 실패가 발생하면, 해당 token들에 대해서만 다시 notification을 보내도록 하는 기능을 추가했습니다.
- bull을 이용한 queue 작업 중, 실패가 발생했을 경우를 확인하기 위해 onFailed 함수를 추가했습니다.


## PR Checklist

- [x] 환경에 따른 실행 여부를 확인하였나요?
- [x] 변경 내용에 관한 테스트를 진행하였나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **새로운 기능**
  - 작업 실패 시 오류 메시지를 기록하는 `onFailed` 메서드가 추가되었습니다.
  
- **리팩터**
  - 작업 제거 이벤트 처리 방식을 간소화하여, 객체 대신 문자열 식별자를 사용하도록 개선하였습니다.
  - 관련 로깅 메시지가 업데이트되어 시스템 모니터링과 유지보수성이 향상되었습니다.
  - 토큰 업데이트 메서드의 파라미터 이름을 일관성 있게 변경하였습니다.

- **버그 수정**
  - 알림 전송 시 배치 처리 방식을 개선하여 오류 처리 능력을 향상시켰습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->