### PR TITLE
fix: change order of function execution related to notification

### DIFF
--- a/apps/api/src/notice/notice.service.ts
+++ b/apps/api/src/notice/notice.service.ts
@@ -189,6 +189,16 @@ export class NoticeService {
       imageUrl: notice.imageUrls ? notice.imageUrls[0] : undefined,
     };
 
+    await this.noticeRepository
+      .updatePublishedAt(id, new Date())
+      .catch((error) => {
+        this.logger.error(
+          `Failed to update publishedAt for notice ${id}: `,
+          error,
+        );
+        throw new InternalServerErrorException('failed to update publishedAt');
+      });
+
     await this.fcmService.deleteMessageJobIdPattern(notice.id.toString());
     await this.fcmService
       .postMessage(
@@ -204,16 +214,6 @@ export class NoticeService {
           error,
         );
         throw new InternalServerErrorException('failed to send notification');
-      });
-
-    await this.noticeRepository
-      .updatePublishedAt(id, new Date())
-      .catch((error) => {
-        this.logger.error(
-          `Failed to update publishedAt for notice ${id}: `,
-          error,
-        );
-        throw new InternalServerErrorException('failed to update publishedAt');
       });
 
     return notice;


### PR DESCRIPTION
# Pull request

## 개요
publishedAt이 업데이트 된 후에, 알림이 가도록 순서를 수정했습니다.
알림을 보내는 기능은 실패했을 경우에 재시도를 하기 때문에,
이와 같이 함수 실행 순서를 변경하면 publishedAt의 업데이트와 알림 전송의 sync를 맞출 수 있을 것입니다.
- Issue
Resolves #131


## PR Checklist

- [ ] 환경에 따른 실행 여부를 확인하였나요?
- [ ] 변경 내용에 관한 테스트를 진행하였나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Notice 전송 기능의 내부 로직을 최적화하여 중복된 코드 제거 및 오류 처리 방식을 개선했습니다. 이로 인해 Notice 전송 과정이 더욱 안정되고 일관되게 처리되어, 서비스 신뢰성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->