### PR TITLE
Fix notification with FCM token

### DIFF
--- a/apps/api/src/fcm/fcm.module.ts
+++ b/apps/api/src/fcm/fcm.module.ts
@@ -6,6 +6,7 @@ import { FcmConsumer } from './fcm.consumer';
 import { PrismaModule } from '@lib/prisma';
 import { LoggerModule } from '@lib/logger';
 import { CustomConfigModule } from '@lib/custom-config';
+import { UserModule } from '../user/user.module';
 
 @Module({
   imports: [
@@ -13,6 +14,7 @@ import { CustomConfigModule } from '@lib/custom-config';
     PrismaModule,
     BullModule.registerQueue({ name: 'fcm' }),
     LoggerModule,
+    UserModule,
   ],
   providers: [FcmService, FcmRepository, FcmConsumer],
   exports: [FcmService],

--- a/apps/api/src/fcm/fcm.service.ts
+++ b/apps/api/src/fcm/fcm.service.ts
@@ -7,6 +7,7 @@ import { InjectQueue } from '@nestjs/bull';
 import { Queue } from 'bull';
 import { Loggable } from '@lib/logger/decorator/loggable';
 import { CustomConfigService } from '@lib/custom-config';
+import { UserService } from '../user/user.service';
 
 @Injectable()
 @Loggable()
@@ -17,6 +18,7 @@ export class FcmService {
     @InjectQueue('fcm') private readonly fcmQueue: Queue,
     private readonly customConfigService: CustomConfigService,
     private readonly fcmRepository: FcmRepository,
+    private readonly userService: UserService,
   ) {
     this.app = initializeApp({
       credential: cert({
@@ -76,73 +78,99 @@ export class FcmService {
       return [[...first, token], ...array];
     }, []);
 
-    const results = await Promise.allSettled(
-      batches.map(async (subTokens) => {
-        await this._postMessage(notification, subTokens, data).catch(
-          (error) => {
-            this.logger.error('Error while sending notification: ', error);
-            throw error;
-          },
+    await Promise.allSettled(
+      batches.map(async (batch, idx) => {
+        const failedTokensToRetry = await this._postMessage(
+          notification,
+          batch,
+          data,
         );
+
+        if (failedTokensToRetry.length > 0) {
+          this.logger.error(`Some fcm token in batch${idx} failed to send`);
+          this.logger.debug(
+            `Retrying failed tokens in batch${idx} (${failedTokensToRetry.length} tokens)`,
+          );
+          await new Promise((resolve) => setTimeout(resolve, 2000));
+          const secondFailedToken = await this._postMessage(
+            notification,
+            failedTokensToRetry,
+            data,
+          );
+
+          if (secondFailedToken.length > 0) {
+            this.logger.error(
+              `Also failed to send ${secondFailedToken.length} notification in batch${idx} at second try`,
+            );
+          } else {
+            this.logger.debug(
+              `Every failed notifications in batch${idx} sent successfully at second try`,
+            );
+          }
+        } else {
+          this.logger.debug(
+            `All notifications in batch${idx} sent successfully at first try`,
+          );
+        }
       }),
     );
-
-    const failedTokens = results
-      .map((result, index) =>
-        result.status === 'rejected' ? batches[index] : null,
-      )
-      .filter((batch): batch is string[] => batch !== null)
-      .flat();
-
-    if (failedTokens.length > 0) {
-      this.logger.warn('Some notifications permanently failed: ', failedTokens);
-    } else {
-      this.logger.debug('All notifications sent successfully');
-    }
-
-    if (failedTokens.length > 0) {
-      this.logger.debug(
-        `Retrying failed tokens (${failedTokens.length} tokens)`,
-      );
-      await new Promise((resolve) => setTimeout(resolve, 2000));
-      await this._postMessage(notification, failedTokens, data);
-
-      this.logger.debug('Retry completed');
-    }
   }
 
   async _postMessage(
     notification: Notification,
     tokens: string[],
     data?: Record<string, string>,
-  ): Promise<void> {
+  ): Promise<string[]> {
     // send message to each token
-    const result = await getMessaging(this.app).sendEachForMulticast({
-      tokens,
-      notification,
-      apns: { payload: { aps: { mutableContent: true } } },
-      data,
-    });
+    const result = await Promise.allSettled(
+      tokens.map((token) =>
+        getMessaging(this.app).send({
+          token,
+          notification,
+          apns: { payload: { aps: { mutableContent: true } } },
+          data,
+        }),
+      ),
+    );
 
     // update success and fail count
-    const responses = result.responses.map((res, idx) => ({
+    const responses = result.map((res, idx) => ({
       res,
       token: tokens[idx],
     }));
-    const succeed = responses.filter(({ res }) => res.success);
-    const failed = responses.filter(({ res }) => !res.success);
+
+    const succeed = responses.filter(({ res }) => res.status === 'fulfilled');
+    const failed = responses.filter(({ res }) => res.status === 'rejected');
+
+    const failedTokensToRetry = (
+      await Promise.all(
+        failed.map(async ({ res, token }) => {
+          if (
+            res.status === 'rejected' &&
+            [
+              'messaging/invalid-argument',
+              'messaging/unregistered',
+              'messaging/third-party-auth-error',
+            ].includes(res.reason.code)
+          ) {
+            await this.userService.deleteFcmToken(token);
+            return null;
+          }
+          return token;
+        }),
+      )
+    ).filter((token): token is string => token !== null);
 
     await this.fcmRepository.updateFcmTokensSuccess(
       succeed.map(({ token }) => token),
     );
-    await this.fcmRepository.updateFcmTokensFail(
-      failed.map(({ token }) => token),
-    );
+    await this.fcmRepository.updateFcmTokensFail(failedTokensToRetry);
 
-    // create logs
     await this.fcmRepository.createLogs(
       { notification, data },
       succeed.map(({ token }) => token),
     );
+
+    return failedTokensToRetry;
   }
 }

--- a/apps/api/src/user/user.repository.ts
+++ b/apps/api/src/user/user.repository.ts
@@ -183,4 +183,23 @@ export class UserRepository {
       });
     return { message: 'success', fcmToken: fcmToken };
   }
+
+  async deleteFcmToken(fcmToken: string) {
+    return this.prismaService.fcmToken
+      .delete({
+        where: { fcmTokenId: fcmToken },
+      })
+      .catch((err) => {
+        if (err instanceof PrismaClientKnownRequestError) {
+          if (err.code === 'P2025') {
+            this.logger.debug('fcm token not found');
+            throw new NotFoundException();
+          }
+          this.logger.error(err.message);
+          throw new InternalServerErrorException();
+        }
+        this.logger.error(err);
+        throw new InternalServerErrorException();
+      });
+  }
 }

--- a/apps/api/src/user/user.repository.ts
+++ b/apps/api/src/user/user.repository.ts
@@ -184,22 +184,20 @@ export class UserRepository {
     return { message: 'success', fcmToken: fcmToken };
   }
 
-  async deleteFcmToken(fcmToken: string) {
-    return this.prismaService.fcmToken
+  async deleteFcmToken(fcmToken: string): Promise<void> {
+    await this.prismaService.fcmToken
       .delete({
         where: { fcmTokenId: fcmToken },
       })
       .catch((err) => {
         if (err instanceof PrismaClientKnownRequestError) {
           if (err.code === 'P2025') {
-            this.logger.debug('fcm token not found');
-            throw new NotFoundException();
+            this.logger.debug('fcm token not found. Just ignore it');
           }
           this.logger.error(err.message);
-          throw new InternalServerErrorException();
         }
         this.logger.error(err);
-        throw new InternalServerErrorException();
+        return;
       });
   }
 }

--- a/apps/api/src/user/user.repository.ts
+++ b/apps/api/src/user/user.repository.ts
@@ -193,11 +193,12 @@ export class UserRepository {
         if (err instanceof PrismaClientKnownRequestError) {
           if (err.code === 'P2025') {
             this.logger.debug('fcm token not found. Just ignore it');
+            return;
           }
           this.logger.error(err.message);
         }
         this.logger.error(err);
-        return;
+        throw err;
       });
   }
 }

--- a/apps/api/src/user/user.service.ts
+++ b/apps/api/src/user/user.service.ts
@@ -113,4 +113,8 @@ export class UserService {
   async setFcmToken(userUuid: string, fcmToken: setFcmTokenReq) {
     return this.userRepository.setFcmToken(userUuid, fcmToken);
   }
+
+  async deleteFcmToken(fcmToken: string) {
+    return this.userRepository.deleteFcmToken(fcmToken);
+  }
 }

--- a/prisma/migrations/20250502154948_add_cascade_fcm_token_log/migration.sql
+++ b/prisma/migrations/20250502154948_add_cascade_fcm_token_log/migration.sql
@@ -1,0 +1,5 @@
+-- DropForeignKey
+ALTER TABLE "log" DROP CONSTRAINT "log_fcm_token_id_fkey";
+
+-- AddForeignKey
+ALTER TABLE "log" ADD CONSTRAINT "log_fcm_token_id_fkey" FOREIGN KEY ("fcm_token_id") REFERENCES "fcm_token"("fcm_token_id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -179,7 +179,7 @@ model Log {
   createdAt DateTime @default(now()) @map("created_at")
 
   fcmTokenId String   @map("fcm_token_id")
-  FcmToken   FcmToken @relation(fields: [fcmTokenId], references: [fcmTokenId])
+  FcmToken   FcmToken @relation(fields: [fcmTokenId], references: [fcmTokenId], onDelete: Cascade)
 
   @@map("log")
 }


### PR DESCRIPTION
# Pull request

## 개요
<!-- 어떤 이슈를 해결하였나요? -->
FCM token을 이용하여 알림을 보내는 과정에서 버그를 유발할 수 있는 코드를 수정했습니다.

또한, 최초 알림 전송에 실패한 token을 대상으로 재전송을 시도하는 과정에서
각 token batch마다 몇 개의 token이 알림 전송에 실패했는지 더 자세한 디버그 로그를 출력하도록 변경했습니다.

알림 전송 실패가 토큰 만료 등의 이유인 경우에는 토큰을 삭제하도록 기능을 추가했습니다.

## PR Checklist

- [x] 환경에 따른 실행 여부를 확인하였나요?
- [x] 변경 내용에 관한 테스트를 진행하였나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
	- 잘못된 FCM 토큰을 자동으로 삭제하고, 알림 전송 시 실패한 토큰에 대해 1회 재시도하는 기능이 추가되었습니다.
- **버그 수정**
	- FCM 토큰 삭제 시 관련 로그 데이터도 함께 자동 삭제되도록 데이터베이스 연동이 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->