### PR TITLE
fix: change delete to deleteMany

### DIFF
--- a/apps/api/src/fcm/fcm.service.ts
+++ b/apps/api/src/fcm/fcm.service.ts
@@ -181,16 +181,9 @@ export class FcmService {
       )
       .map(({ token }) => token);
 
-    await Promise.allSettled(
-      tokensToDelete.map(async (token) => {
-        this.userService.deleteFcmToken(token).catch((err) => {
-          this.logger.warn(
-            'Failed to delete fcm token but just ignore it',
-            err,
-          );
-        });
-      }),
-    );
+    await this.userService.deleteFcmTokens(tokensToDelete).catch((err) => {
+      this.logger.warn('Failed to delete fcm tokens but just ignore it', err);
+    });
 
     await this.fcmRepository.updateFcmTokensSuccess(succeed);
     await this.fcmRepository.updateFcmTokensFail(failedTokensToRetry);

--- a/apps/api/src/user/user.repository.ts
+++ b/apps/api/src/user/user.repository.ts
@@ -184,15 +184,15 @@ export class UserRepository {
     return { message: 'success', fcmToken: fcmToken };
   }
 
-  async deleteFcmToken(fcmToken: string): Promise<void> {
+  async deleteFcmTokens(fcmTokens: string[]): Promise<void> {
     await this.prismaService.fcmToken
-      .delete({
-        where: { fcmTokenId: fcmToken },
+      .deleteMany({
+        where: { fcmTokenId: { in: fcmTokens } },
       })
       .catch((err) => {
         if (err instanceof PrismaClientKnownRequestError) {
           if (err.code === 'P2025') {
-            this.logger.debug('fcm token not found. Just ignore it');
+            this.logger.debug('Some fcm token not found. Just ignore it');
             return;
           }
           this.logger.error(err.message);

--- a/apps/api/src/user/user.service.ts
+++ b/apps/api/src/user/user.service.ts
@@ -114,7 +114,7 @@ export class UserService {
     return this.userRepository.setFcmToken(userUuid, fcmToken);
   }
 
-  async deleteFcmToken(fcmToken: string) {
-    return this.userRepository.deleteFcmToken(fcmToken);
+  async deleteFcmTokens(fcmTokens: string[]) {
+    return this.userRepository.deleteFcmTokens(fcmTokens);
   }
 }


### PR DESCRIPTION
# Pull request

## 개요
<!-- 어떤 이슈를 해결하였나요? -->
유효하지 않은 FCM token을 삭제하는 과정을 deleteMany를 통해 일괄 삭제하도록 수정했습니다.
빠른 Production 반영을 위해 PR을 생성했습니다.

## PR Checklist

- [x] 환경에 따른 실행 여부를 확인하였나요?
- [x] 변경 내용에 관한 테스트를 진행하였나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - FCM 토큰 삭제 방식이 개선되어 여러 토큰을 한 번에 일괄 삭제하도록 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->