### PR TITLE
fix: remove fcm jobs

### DIFF
--- a/apps/api/src/fcm/fcm.service.ts
+++ b/apps/api/src/fcm/fcm.service.ts
@@ -133,7 +133,7 @@ export class FcmService {
   }
 
   async deleteMessageJobIdPattern(name: string): Promise<void> {
-    await this.fcmQueue.removeJobs(name);
+    await this.fcmQueue.removeJobs(`${name}-*`);
   }
 
   async postMessage(


### PR DESCRIPTION
# Pull request

## 개요
<!-- 어떤 이슈를 해결하였나요? -->
하나의 공지에 대한 notification job을 모두 삭제하도록 수정했습니다.

## PR Checklist

- [ ] 환경에 따른 실행 여부를 확인하였나요?
- [ ] 변경 내용에 관한 테스트를 진행하였나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 메시지 작업 삭제 시, 지정된 이름으로 시작하는 모든 관련 작업이 한 번에 삭제되도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->