### PR TITLE
fix: crawler error handling

### DIFF
--- a/apps/crawler/src/crawler.service.ts
+++ b/apps/crawler/src/crawler.service.ts
@@ -57,10 +57,6 @@ export class CrawlerService {
   }> {
     return this.httpService.get(this.targetUrl).pipe(
       timeout(60e3),
-      catchError((err) => {
-        this.logger.error(err);
-        return throwError(() => new Error(err));
-      }),
       map((res) => load(res.data)),
       map(($) => $('table > tbody > tr')),
       concatMap(($) => $.toArray().map((value: any) => load(value))),
@@ -77,6 +73,10 @@ export class CrawlerService {
         id: Number.parseInt(meta.link.split('no=')[1].split('&')[0]),
         ...meta,
       })),
+      catchError((err) => {
+        this.logger.error(err);
+        return throwError(() => new Error(err));
+      }),
     );
   }
 
@@ -91,10 +91,6 @@ export class CrawlerService {
     return this.httpService.get(link).pipe(
       timeout(60e3),
       map((res) => load(res.data)),
-      catchError((err) => {
-        this.logger.error(err);
-        return throwError(() => new Error(err));
-      }),
       map(($) => ({
         content: $('.bd_detail_content').html()?.trim(),
         files: $('.bd_detail_file > ul > li > a')
@@ -111,6 +107,10 @@ export class CrawlerService {
               | 'etc',
           })),
       })),
+      catchError((err) => {
+        this.logger.error(err);
+        return throwError(() => new Error(err));
+      }),
     );
   }
 }

--- a/apps/crawler/src/crawler.service.ts
+++ b/apps/crawler/src/crawler.service.ts
@@ -59,7 +59,7 @@ export class CrawlerService {
       timeout(60e3),
       catchError((err) => {
         this.logger.error(err);
-        return throwError(() => err);
+        return throwError(() => new Error(err));
       }),
       map((res) => load(res.data)),
       map(($) => $('table > tbody > tr')),
@@ -93,7 +93,7 @@ export class CrawlerService {
       map((res) => load(res.data)),
       catchError((err) => {
         this.logger.error(err);
-        return throwError(() => err);
+        return throwError(() => new Error(err));
       }),
       map(($) => ({
         content: $('.bd_detail_content').html()?.trim(),


### PR DESCRIPTION
# Pull request

## 개요
<!-- 어떤 이슈를 해결하였나요? -->
timeout 또는 오류로 인해 crawler가 중단될 때 오류 로그 생성, timeout 시간 변경

## PR Checklist

- [X] 환경에 따른 실행 여부를 확인하였나요?
- [X] 변경 내용에 관한 테스트를 진행하였나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 공지 목록 및 상세 조회의 네트워크 타임아웃을 10초에서 60초로 확대해, 느린 네트워크 환경에서도 요청 실패와 로딩 중단 현상을 줄였습니다. 보다 안정적으로 공지 데이터를 불러올 수 있습니다.
  * 오류 처리 방식 개선 및 오류 로깅 도입으로 간헐적 로딩 실패의 원인 파악이 쉬워져, 공지 조회 경험의 신뢰성과 일관성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->