### PR TITLE
feat: modify group db table and change response of notice api

### DIFF
--- a/apps/api/src/notice/dto/res/generalNotice.dto.ts
+++ b/apps/api/src/notice/dto/res/generalNotice.dto.ts
@@ -53,7 +53,7 @@ export class GeneralNoticeDto {
   @Exclude()
   authorId: string;
   @Exclude()
-  group: Group | null;
+  groupId: string | null;
 
   @Expose()
   @ApiProperty()
@@ -69,7 +69,7 @@ export class GeneralNoticeDto {
 
   @Expose()
   @ApiProperty()
-  groupId: string | null;
+  group: Group | null;
 
   @Expose()
   @Type(() => AuthorDto)

--- a/apps/api/src/notice/notice.controller.ts
+++ b/apps/api/src/notice/notice.controller.ts
@@ -105,7 +105,7 @@ export class NoticeController {
   @UseGuards(GroupsGuard)
   async createNotice(
     @GetUser() user: User,
-    @GetGroups() groups: GroupsUserInfo,
+    @GetGroups() groups: GroupsUserInfo[],
     @Body() createNoticeDto: CreateNoticeDto,
   ): Promise<ExpandedGeneralNoticeDto> {
     return this.noticeService.createNotice(createNoticeDto, user.uuid, groups);
@@ -213,7 +213,7 @@ export class NoticeController {
   async updateNotice(
     @Param('id', ParseIntPipe) id: number,
     @GetUser() user: User,
-    @GetGroups() groups: GroupsUserInfo,
+    @GetGroups() groups: GroupsUserInfo[],
     @Query() query: UpdateNoticeQueryDto,
     @Body() body: UpdateNoticeDto,
   ): Promise<ExpandedGeneralNoticeDto> {
@@ -252,7 +252,7 @@ export class NoticeController {
   @UseGuards(GroupsGuard)
   async deleteNotice(
     @GetUser() user: User,
-    @GetGroups() groups: GroupsUserInfo,
+    @GetGroups() groups: GroupsUserInfo[],
     @Param('id', ParseIntPipe)
     id: number,
   ) {

--- a/apps/api/src/notice/notice.repository.ts
+++ b/apps/api/src/notice/notice.repository.ts
@@ -18,6 +18,7 @@ import {
 } from './dto/req/updateNotice.dto';
 import { PrismaService } from '@lib/prisma';
 import { Loggable } from '@lib/logger/decorator/loggable';
+import { GroupsUserInfo } from '@lib/infoteam-groups/types/groups.type';
 
 @Injectable()
 @Loggable()
@@ -335,12 +336,12 @@ export class NoticeRepository {
       userUuid,
       publishedAt,
       createdAt,
-      groupName,
+      group,
     }: {
       userUuid: string;
       publishedAt: Date;
       createdAt?: Date;
-      groupName?: string;
+      group?: GroupsUserInfo;
     },
   ): Promise<NoticeFullContent> {
     const findTags = await this.prismaService.tag.findMany({
@@ -351,7 +352,7 @@ export class NoticeRepository {
       },
     });
 
-    if (groupId && groupName) {
+    if (groupId && group) {
       await this.prismaService.group.upsert({
         where: {
           uuid: groupId,
@@ -359,7 +360,8 @@ export class NoticeRepository {
         update: {},
         create: {
           uuid: groupId,
-          name: groupName,
+          name: group?.name,
+          profileImageUrl: group?.profileImageUrl,
         },
       });
     }
@@ -404,7 +406,7 @@ export class NoticeRepository {
           },
           category,
           group:
-            groupId === undefined || groupName === undefined
+            groupId === undefined || group === undefined
               ? undefined
               : {
                   connect: { uuid: groupId },

--- a/apps/api/src/notice/notice.service.ts
+++ b/apps/api/src/notice/notice.service.ts
@@ -106,10 +106,10 @@ export class NoticeService {
     userUuid: string,
     groups?: GroupsUserInfo[],
   ): Promise<ExpandedGeneralNoticeDto> {
-    let groupName;
+    let matchingGroup;
 
     if (createNoticeDto.groupId !== undefined && groups !== undefined) {
-      const matchingGroup = groups.find(
+      matchingGroup = groups.find(
         (group) =>
           group.uuid === createNoticeDto.groupId &&
           group.Role.some((role) =>
@@ -122,8 +122,6 @@ export class NoticeService {
       if (!matchingGroup) {
         throw new ForbiddenException();
       }
-
-      groupName = matchingGroup.name;
     } else if (createNoticeDto.groupId) {
       throw new UnauthorizedException();
     }
@@ -140,7 +138,7 @@ export class NoticeService {
         userUuid,
         publishedAt: new Date(new Date().getTime() + this.fcmDelay),
         createdAt: undefined,
-        groupName,
+        group: matchingGroup,
       },
     );
 

--- a/apps/api/src/notice/notice.service.ts
+++ b/apps/api/src/notice/notice.service.ts
@@ -104,7 +104,7 @@ export class NoticeService {
   async createNotice(
     createNoticeDto: CreateNoticeDto,
     userUuid: string,
-    groups?: GroupsUserInfo,
+    groups?: GroupsUserInfo[],
   ): Promise<ExpandedGeneralNoticeDto> {
     let groupName;
 
@@ -267,7 +267,7 @@ export class NoticeService {
     query: UpdateNoticeQueryDto,
     id: number,
     userUuid: string,
-    groups?: GroupsUserInfo,
+    groups?: GroupsUserInfo[],
   ): Promise<ExpandedGeneralNoticeDto> {
     const notice = await this.noticeRepository.getNotice(id);
 
@@ -313,7 +313,7 @@ export class NoticeService {
   async deleteNotice(
     id: number,
     userUuid: string,
-    groups?: GroupsUserInfo,
+    groups?: GroupsUserInfo[],
   ): Promise<void> {
     await this.fcmService.deleteMessageJobIdPattern(id.toString());
     const notice = await this.noticeRepository.getNotice(id);

--- a/apps/api/src/user/decorator/get-groups.decorator.ts
+++ b/apps/api/src/user/decorator/get-groups.decorator.ts
@@ -2,7 +2,7 @@ import { createParamDecorator, ExecutionContext } from '@nestjs/common';
 import { GroupsUserInfo } from '@lib/infoteam-groups/types/groups.type';
 
 export const GetGroups = createParamDecorator(
-  (_data, ctx: ExecutionContext): GroupsUserInfo | undefined => {
+  (_data, ctx: ExecutionContext): GroupsUserInfo[] | undefined => {
     const req = ctx.switchToHttp().getRequest();
     return req.groups;
   },

--- a/docs/erd.md
+++ b/docs/erd.md
@@ -41,6 +41,7 @@ ETC ETC
   "group" {
     String uuid "🗝️"
     String name 
+    String profileImageUrl "❓"
     }
   
 

--- a/libs/infoteam-groups/src/guard/groups.guard.ts
+++ b/libs/infoteam-groups/src/guard/groups.guard.ts
@@ -10,7 +10,7 @@ import { GroupsUserInfo } from '../types/groups.type';
 export class GroupsGuard extends AuthGuard('groups') {
   handleRequest(
     err: Error,
-    user: { groups: GroupsUserInfo },
+    user: { groups: GroupsUserInfo[] },
     _: any,
     context: ExecutionContext,
   ): any {

--- a/libs/infoteam-groups/src/guard/groups.strategy.ts
+++ b/libs/infoteam-groups/src/guard/groups.strategy.ts
@@ -11,7 +11,7 @@ export class GroupsStrategy extends PassportStrategy(Strategy, 'groups') {
     super();
   }
 
-  async validate(req: Request): Promise<{ groups: GroupsUserInfo } | void> {
+  async validate(req: Request): Promise<{ groups: GroupsUserInfo[] } | void> {
     const token = req.get('groups-token');
     if (!token) return;
     const groups = await this.infoteamGroupsService.getGroupsUserInfo(token);

--- a/libs/infoteam-groups/src/infoteam-groups.service.ts
+++ b/libs/infoteam-groups/src/infoteam-groups.service.ts
@@ -23,10 +23,10 @@ export class InfoteamGroupsService {
     this.groupsUrl = this.customConfigService.GROUPS_URL;
   }
 
-  async getGroupsUserInfo(accessToken: string): Promise<GroupsUserInfo> {
+  async getGroupsUserInfo(accessToken: string): Promise<GroupsUserInfo[]> {
     const userInfoResponse = await firstValueFrom(
       this.httpService
-        .get<GroupsUserInfo>(this.groupsUrl + '/third-party/userinfo', {
+        .get<GroupsUserInfo[]>(this.groupsUrl + '/third-party/userinfo', {
           headers: {
             Authorization: `Bearer ${accessToken}`,
           },

--- a/libs/infoteam-groups/src/types/groups.type.ts
+++ b/libs/infoteam-groups/src/types/groups.type.ts
@@ -14,4 +14,5 @@ export type GroupsUserInfo = {
   }[];
   uuid: string;
   name: string;
+  profileImageUrl: string;
 };

--- a/libs/infoteam-groups/src/types/groups.type.ts
+++ b/libs/infoteam-groups/src/types/groups.type.ts
@@ -14,4 +14,4 @@ export type GroupsUserInfo = {
   }[];
   uuid: string;
   name: string;
-}[];
+};

--- a/prisma/migrations/20250826134149_add_group_image_url/migration.sql
+++ b/prisma/migrations/20250826134149_add_group_image_url/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "group" ADD COLUMN     "profileImageUrl" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -58,8 +58,9 @@ model UserRecord {
 }
 
 model Group {
-  uuid String @id @db.Uuid
-  name String
+  uuid            String @id @db.Uuid
+  name            String
+  profileImageUrl String?
 
   Notice Notice[]
 


### PR DESCRIPTION
# Pull request

## 개요
group table에 profileImageUrl 추가
그에 따른 notice api의 response 수정 (group의 name, profileImageUrl이 보이도록)

## PR Checklist

- [X] 환경에 따른 실행 여부를 확인하였나요?
- [X] 변경 내용에 관한 테스트를 진행하였나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 공지 생성/수정/삭제 시 다중 그룹 컨텍스트를 지원합니다.
  - 그룹 프로필 이미지(프로필 이미지 URL)를 지원합니다.

- 개선
  - 공지 작업 시 그룹 권한 검증이 강화되었습니다(쓰기/삭제 권한 확인). 권한이 없을 경우 접근이 제한됩니다.

- 문서
  - ER 다이어그램에 그룹 프로필 이미지 필드를 반영했습니다.

- 데이터베이스
  - 그룹에 프로필 이미지 URL 컬럼이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->