### PR TITLE
make fcm in crawler dir, add enqueue process when use createcrawl

### DIFF
--- a/apps/crawler/src/crawler-fcm/crawler-fcm.module.ts
+++ b/apps/crawler/src/crawler-fcm/crawler-fcm.module.ts
@@ -1,0 +1,19 @@
+import { Module } from '@nestjs/common';
+import { BullModule } from '@nestjs/bull';
+import { LoggerModule } from '@lib/logger';
+import { PrismaModule } from '@lib/prisma';
+import { CustomConfigModule } from '@lib/custom-config';
+import { CrawlerFcmService } from './crawler-fcm.service';
+import { CrawlerFcmRepository } from './crawler-fcm.repository';
+
+@Module({
+  imports: [
+    CustomConfigModule,
+    PrismaModule,
+    BullModule.registerQueue({ name: 'fcm' }),
+    LoggerModule,
+  ],
+  providers: [CrawlerFcmService, CrawlerFcmRepository],
+  exports: [CrawlerFcmService],
+})
+export class CrawlerFcmModule {}

--- a/apps/crawler/src/crawler-fcm/crawler-fcm.repository.ts
+++ b/apps/crawler/src/crawler-fcm/crawler-fcm.repository.ts
@@ -1,0 +1,24 @@
+import {
+  Injectable,
+  InternalServerErrorException,
+  Logger,
+} from '@nestjs/common';
+import { PrismaService } from '@lib/prisma';
+import { FcmToken } from '@prisma/client';
+
+@Injectable()
+export class CrawlerFcmRepository {
+  private readonly logger = new Logger(CrawlerFcmRepository.name);
+  constructor(private readonly prisma: PrismaService) {}
+
+  async getAllFcmTokens(): Promise<FcmToken[]> {
+    // API의 FcmRepository와 동일한 쿼리
+    try {
+      return await this.prisma.fcmToken.findMany();
+    } catch (err) {
+      this.logger.error('getAllFcmTokens');
+      this.logger.debug(err);
+      throw new InternalServerErrorException('Database error');
+    }
+  }
+}

--- a/apps/crawler/src/crawler-fcm/crawler-fcm.repository.ts
+++ b/apps/crawler/src/crawler-fcm/crawler-fcm.repository.ts
@@ -9,16 +9,13 @@ import { FcmToken } from '@prisma/client';
 @Injectable()
 export class CrawlerFcmRepository {
   private readonly logger = new Logger(CrawlerFcmRepository.name);
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(private readonly prismaService: PrismaService) {}
 
   async getAllFcmTokens(): Promise<FcmToken[]> {
-    // API의 FcmRepository와 동일한 쿼리
-    try {
-      return await this.prisma.fcmToken.findMany();
-    } catch (err) {
+    return this.prismaService.fcmToken.findMany().catch((err) => {
       this.logger.error('getAllFcmTokens');
       this.logger.debug(err);
       throw new InternalServerErrorException('Database error');
-    }
+    });
   }
 }

--- a/apps/crawler/src/crawler-fcm/crawler-fcm.service.ts
+++ b/apps/crawler/src/crawler-fcm/crawler-fcm.service.ts
@@ -1,0 +1,107 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectQueue } from '@nestjs/bull';
+import { Queue } from 'bull';
+import { CustomConfigService } from '@lib/custom-config';
+import { CrawlerFcmRepository } from './crawler-fcm.repository';
+
+export enum FcmTargetUser {
+  All = 'all',
+  AllowAlarm = 'allowAlarm',
+}
+
+type NotificationLike = {
+  title: string;
+  body?: string;
+  imageUrl?: string;
+};
+
+@Injectable()
+export class CrawlerFcmService {
+  private readonly logger = new Logger(CrawlerFcmService.name);
+
+  constructor(
+    @InjectQueue('fcm') private readonly fcmQueue: Queue,
+    private readonly config: CustomConfigService,
+    private readonly repo: CrawlerFcmRepository,
+  ) {}
+
+  private createBatches<T>(arr: T[], size: number): T[][] {
+    const out: T[][] = [];
+    for (let i = 0; i < arr.length; i += size) out.push(arr.slice(i, i + size));
+    return out;
+  }
+
+  private async getTokensWithTargetCondition(
+    target: FcmTargetUser,
+  ): Promise<string[][]> {
+    const tokens =
+      target === FcmTargetUser.All
+        ? await this.repo.getAllFcmTokens()
+        : await this.repo.getAllFcmTokens();
+    const ids = tokens.map(({ fcmTokenId }) => fcmTokenId);
+    const BATCH_SIZE = 100;
+    return this.createBatches(ids, BATCH_SIZE);
+  }
+
+  private async processBatches(
+    batches: string[][],
+    name: string, // 잡 그룹 키 (noticeId 사용)
+    notification: NotificationLike,
+    attempt: number,
+    data?: Record<string, string>,
+  ): Promise<string[][]> {
+    const results = await Promise.allSettled(
+      batches.map((tokens, index) =>
+        this.fcmQueue.add(
+          { notification, tokens, data }, // API Consumer가 그대로 사용
+          {
+            delay: this.config.FCM_DELAY, // 지연 전송
+            removeOnComplete: true,
+            removeOnFail: true,
+            jobId: `${name}-${index}-${attempt}`, // 패턴 호환
+          },
+        ),
+      ),
+    );
+
+    const failed = results
+      .map((res, idx) => ({ res, idx }))
+      .filter(({ res }) => res.status === 'rejected')
+      .map(({ idx }) => batches[idx]);
+
+    if (failed.length === 0) {
+      this.logger.debug(
+        `All ${batches.length} batches enqueued (attempt ${attempt}).`,
+      );
+      return [];
+    }
+    this.logger.error(
+      `Failed ${failed.length}/${batches.length} batches (attempt ${attempt}).`,
+    );
+    return failed;
+  }
+
+  async postMessageWithDelay(
+    name: string, // noticeId 문자열 사용
+    notification: NotificationLike,
+    target: FcmTargetUser,
+    data?: Record<string, string>,
+  ): Promise<void> {
+    const tokenBatches = await this.getTokensWithTargetCondition(target);
+    const failed1 = await this.processBatches(
+      tokenBatches,
+      name,
+      notification,
+      1,
+      data,
+    );
+    if (failed1.length > 0) {
+      this.logger.debug(`Retrying ${failed1.length} batches (attempt 2)`);
+      await this.processBatches(failed1, name, notification, 2, data);
+    }
+  }
+
+  async deleteMessageJobIdPattern(name: string): Promise<void> {
+    await this.fcmQueue.removeJobs(`${name}-*`);
+  }
+}

--- a/apps/crawler/src/crawler-fcm/crawler-fcm.service.ts
+++ b/apps/crawler/src/crawler-fcm/crawler-fcm.service.ts
@@ -99,8 +99,4 @@ export class CrawlerFcmService {
       await this.processBatches(failedBatches, noticeId, notification, 2, data);
     }
   }
-
-  async deleteMessageJobIdPattern(name: string): Promise<void> {
-    await this.fcmQueue.removeJobs(`${name}-*`);
-  }
 }

--- a/apps/crawler/src/crawler.module.ts
+++ b/apps/crawler/src/crawler.module.ts
@@ -5,9 +5,18 @@ import { HttpModule } from '@nestjs/axios';
 import { CrawlerRepository } from './crawler.repository';
 import { UserModule } from './user/user.module';
 import { LoggerModule } from '@lib/logger';
+import { BullModule } from '@nestjs/bull';
+import { CrawlerFcmModule } from './crawler-fcm/crawler-fcm.module';
 
 @Module({
-  imports: [PrismaModule, HttpModule, UserModule, LoggerModule],
+  imports: [
+    PrismaModule,
+    HttpModule,
+    UserModule,
+    LoggerModule,
+    BullModule.registerQueue({ name: 'fcm' }),
+    CrawlerFcmModule,
+  ],
   providers: [CrawlerService, CrawlerRepository],
   exports: [CrawlerService],
 })

--- a/apps/crawler/src/crawler.module.ts
+++ b/apps/crawler/src/crawler.module.ts
@@ -5,7 +5,6 @@ import { HttpModule } from '@nestjs/axios';
 import { CrawlerRepository } from './crawler.repository';
 import { UserModule } from './user/user.module';
 import { LoggerModule } from '@lib/logger';
-import { BullModule } from '@nestjs/bull';
 import { CrawlerFcmModule } from './crawler-fcm/crawler-fcm.module';
 
 @Module({
@@ -14,7 +13,6 @@ import { CrawlerFcmModule } from './crawler-fcm/crawler-fcm.module';
     HttpModule,
     UserModule,
     LoggerModule,
-    BullModule.registerQueue({ name: 'fcm' }),
     CrawlerFcmModule,
   ],
   providers: [CrawlerService, CrawlerRepository],

--- a/apps/crawler/src/crawler.service.ts
+++ b/apps/crawler/src/crawler.service.ts
@@ -13,9 +13,6 @@ import {
 import { CrawlerRepository } from './crawler.repository';
 import { UserService } from './user/user.service';
 import { Loggable } from '@lib/logger/decorator/loggable';
-import { Queue } from 'bull';
-import { InjectQueue } from '@nestjs/bull';
-import { CustomConfigService } from '@lib/custom-config';
 import { htmlToText } from 'html-to-text';
 import {
   CrawlerFcmService,
@@ -30,8 +27,6 @@ export class CrawlerService {
   private readonly targetUrl =
     'https://www.gist.ac.kr/kr/html/sub05/050209.html';
   constructor(
-    @InjectQueue('fcm') private readonly fcmQueue: Queue,
-    private readonly customConfigService: CustomConfigService,
     private readonly userService: UserService,
     private readonly httpService: HttpService,
     private readonly crawlerRepository: CrawlerRepository,
@@ -40,18 +35,6 @@ export class CrawlerService {
 
   async checkCrawlData(url: string): Promise<Crawl | null> {
     return this.crawlerRepository.checkCrawlData(url);
-  }
-
-  private toPlainText(html?: string): string | undefined {
-    if (!html) return undefined;
-    return htmlToText(html, {
-      selectors: [
-        { selector: 'a', options: { ignoreHref: true } },
-        { selector: 'img', format: 'skip' },
-      ],
-    })
-      .slice(0, 1000)
-      .replace(/\s+/gm, ' ');
   }
 
   async createCrawl(


### PR DESCRIPTION
# Pull request

## 개요
<!-- 어떤 이슈를 해결하였나요? -->

## PR Checklist

- [ ] 환경에 따른 실행 여부를 확인하였나요?
- [ ] 변경 내용에 관한 테스트를 진행하였나요?


미안합니다...


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신기능**
  * 새 크롤링 생성 시 FCM 푸시 알림을 자동으로 비동기 발송합니다.
  * 알림에 제목, HTML을 텍스트로 변환한 요약 본문과 해당 항목으로 이동하는 링크가 포함됩니다.
  * 전체 사용자 대상 배치 전송, 구성 가능한 지연 전송 및 최대 2회 재시도로 전송 안정성을 확보했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->