### PR TITLE
fix: change type of group from Group to GroupDto

### DIFF
--- a/apps/api/src/notice/dto/res/generalNotice.dto.ts
+++ b/apps/api/src/notice/dto/res/generalNotice.dto.ts
@@ -28,7 +28,7 @@ class GroupDto {
   name: string;
 
   @ApiProperty()
-  profileImageUrl: string;
+  profileImageUrl: string | null;
 }
 
 export class GeneralNoticeDto {

--- a/apps/api/src/notice/dto/res/generalNotice.dto.ts
+++ b/apps/api/src/notice/dto/res/generalNotice.dto.ts
@@ -5,7 +5,6 @@ import {
   Crawl,
   File,
   FileType,
-  Group,
   Reaction,
   Tag,
   User,
@@ -19,6 +18,17 @@ export class AuthorDto {
 
   @ApiProperty()
   name: string;
+}
+
+class GroupDto {
+  @ApiProperty()
+  uuid: string;
+
+  @ApiProperty()
+  name: string;
+
+  @ApiProperty()
+  profileImageUrl: string;
 }
 
 export class GeneralNoticeDto {
@@ -69,7 +79,7 @@ export class GeneralNoticeDto {
 
   @Expose()
   @ApiProperty()
-  group: Group | null;
+  group: GroupDto | null;
 
   @Expose()
   @Type(() => AuthorDto)

--- a/apps/api/src/notice/dto/res/generalNotice.dto.ts
+++ b/apps/api/src/notice/dto/res/generalNotice.dto.ts
@@ -78,7 +78,8 @@ export class GeneralNoticeDto {
   }
 
   @Expose()
-  @ApiProperty()
+  @Type(() => GroupDto)
+  @ApiProperty({ type: GroupDto })
   group: GroupDto | null;
 
   @Expose()


### PR DESCRIPTION
# Pull request

## 개요
swagger schema에 group 정보 추가

## PR Checklist

- [X] 환경에 따른 실행 여부를 확인하였나요?
- [X] 변경 내용에 관한 테스트를 진행하였나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - 공지의 그룹 정보 API 응답을 간소화하여 uuid, name, profileImageUrl만 제공하도록 정리했습니다.
  - 그룹 관련 반환 필드가 축소되어 불필요한 정보 노출이 제거되고 응답 일관성과 보안이 강화되었습니다.
  - 기존에 그룹의 추가 필드에 의존하던 화면이나 통합은 필드 변경에 맞춰 업데이트가 필요할 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->