### PR TITLE
change consent  to true

### DIFF
--- a/apps/api/src/user/user.controller.ts
+++ b/apps/api/src/user/user.controller.ts
@@ -111,9 +111,9 @@ export class UserController {
   @UseGuards(IdPGuard)
   async getUserInfo(
     @GetIdPUser() userInfo: UserInfo,
-    @GetUser() user: User,
+    //@GetUser() user: User,
   ): Promise<UserInfoRes> {
-    return { ...userInfo, consent: user.consent };
+    return { ...userInfo, consent: true };
   }
 
   @ApiOperation({

--- a/apps/api/src/user/user.controller.ts
+++ b/apps/api/src/user/user.controller.ts
@@ -113,6 +113,7 @@ export class UserController {
     @GetIdPUser() userInfo: UserInfo,
     //@GetUser() user: User,
   ): Promise<UserInfoRes> {
+    //TODO consent : user.consent로 수정하기
     return { ...userInfo, consent: true };
   }
 

--- a/apps/api/src/user/user.repository.ts
+++ b/apps/api/src/user/user.repository.ts
@@ -27,7 +27,7 @@ export class UserRepository {
         create: {
           uuid,
           name,
-          consent: true,
+          consent: false,
         },
         update: {
           name,

--- a/apps/api/src/user/user.repository.ts
+++ b/apps/api/src/user/user.repository.ts
@@ -27,7 +27,7 @@ export class UserRepository {
         create: {
           uuid,
           name,
-          consent: false,
+          consent: true,
         },
         update: {
           name,

--- a/apps/api/src/user/user.service.ts
+++ b/apps/api/src/user/user.service.ts
@@ -63,6 +63,7 @@ export class UserService {
    * @returns user
    */
   async findUserOrCreate(user: Pick<User, 'uuid' | 'name'>): Promise<User> {
+    //TODO consent true로 강제로 바꾼 것 없애기
     const newUser = this.userRepository.findUserOrCreate(user);
     (await newUser).consent = true;
     return newUser;
@@ -71,9 +72,11 @@ export class UserService {
   async findOrCreateTempUser(user: Pick<User, 'name'>): Promise<User> {
     const foundUser = await this.userRepository.findUserByName(user);
     if (foundUser) {
+      //TODO cosent true로 강제로 바꾼 것 없애기
       foundUser.consent = true;
       return foundUser;
     }
+    //TODO cosent true로 강제로 바꾼 것 없애기
     const newUser = await this.userRepository.createTempUser(user);
     newUser.consent = true;
     return newUser;

--- a/apps/api/src/user/user.service.ts
+++ b/apps/api/src/user/user.service.ts
@@ -63,15 +63,20 @@ export class UserService {
    * @returns user
    */
   async findUserOrCreate(user: Pick<User, 'uuid' | 'name'>): Promise<User> {
-    return this.userRepository.findUserOrCreate(user);
+    const newUser = this.userRepository.findUserOrCreate(user);
+    (await newUser).consent = true;
+    return newUser;
   }
 
   async findOrCreateTempUser(user: Pick<User, 'name'>): Promise<User> {
     const foundUser = await this.userRepository.findUserByName(user);
     if (foundUser) {
+      foundUser.consent = true;
       return foundUser;
     }
-    return this.userRepository.createTempUser(user);
+    const newUser = await this.userRepository.createTempUser(user);
+    newUser.consent = true;
+    return newUser;
   }
 
   async setFcmToken(userUuid: string, fcmToken: setFcmTokenReq) {


### PR DESCRIPTION
# Pull request

## 개요
<!-- 어떤 이슈를 해결하였나요? -->

## PR Checklist

- [ ] 환경에 따른 실행 여부를 확인하였나요?
- [ ] 변경 내용에 관한 테스트를 진행하였나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 기존/임시 사용자 조회·생성 시 동의(consent)를 명확히 true로 설정하여 로그인·가입 흐름의 불일치 문제를 해결했습니다.
  * 사용자 생성 및 반환 과정에서 비동기 처리를 보장해 동의 반영 누락과 간헐적 지연을 개선했습니다.
  * 사용자 정보 응답의 동의 표시를 안정적으로 true로 고정해 재동의 요청·접근 제한 상황을 줄였습니다.
  * 관련 엔드포인트 호출 방식이 단순화되어 응답 일관성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->