### PR TITLE
feat: save user profile image

### DIFF
--- a/apps/api/src/auth/auth.repository.ts
+++ b/apps/api/src/auth/auth.repository.ts
@@ -19,7 +19,8 @@ export class AuthRepository {
     uuid,
     name,
     email,
-  }: Pick<User, 'uuid' | 'name' | 'email'>): Promise<User> {
+    picture,
+  }: Pick<User, 'uuid' | 'name' | 'email' | 'picture'>): Promise<User> {
     return await this.prismaService.user
       .upsert({
         where: { uuid },
@@ -27,11 +28,13 @@ export class AuthRepository {
           uuid,
           name,
           email,
+          picture,
           consent: false,
         },
         update: {
           name,
           email,
+          picture,
         },
       })
       .catch((err) => {

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -30,14 +30,13 @@ export class AuthService {
 
   async login(auth: string): Promise<JwtTokenType> {
     const idpToken = auth.split(' ')[1];
-    const { uuid, name, email } =
-      await this.infoteamIdpService.getUserInfo(idpToken);
+    const userinfo = await this.infoteamIdpService.getUserInfo(idpToken);
     const user = await this.authRepository
-      .findUserOrCreate({ uuid, name, email })
+      .findUserOrCreate(userinfo)
       .catch(() => {
         throw new UnauthorizedException();
       });
-    const tokens = await this.issueTokens(uuid);
+    const tokens = await this.issueTokens(userinfo.uuid);
     return { ...tokens, consent_required: user.consent };
   }
 

--- a/apps/api/src/user/dto/res/userInfoRes.dto.ts
+++ b/apps/api/src/user/dto/res/userInfoRes.dto.ts
@@ -21,6 +21,12 @@ export class UserInfoRes implements UserInfo {
   })
   name: string;
 
+  @ApiProperty({
+    description: 'User profile image',
+    example: 'https://bucket.s3.ap-northeast-2.amazonaws.com/1626740269.webp',
+  })
+  picture: string | null;
+
   @ApiPropertyOptional({
     description: 'Student number',
     example: '20212345',

--- a/docs/erd.md
+++ b/docs/erd.md
@@ -26,6 +26,7 @@ ETC ETC
     String uuid "🗝️"
     String name 
     String email "❓"
+    String picture "❓"
     DateTime created_at 
     Boolean consent 
     }

--- a/libs/infoteam-idp/src/infoteam-idp.service.ts
+++ b/libs/infoteam-idp/src/infoteam-idp.service.ts
@@ -57,7 +57,7 @@ export class InfoteamIdpService {
       picture,
       student_id: studentNumber,
     } = userInfoResponse.data;
-    return { uuid, name, email, picture, studentNumber };
+    return { uuid, name, email, picture: picture ?? null, studentNumber };
   }
 
   //deprecated

--- a/libs/infoteam-idp/src/infoteam-idp.service.ts
+++ b/libs/infoteam-idp/src/infoteam-idp.service.ts
@@ -54,9 +54,10 @@ export class InfoteamIdpService {
       sub: uuid,
       name,
       email,
+      picture,
       student_id: studentNumber,
     } = userInfoResponse.data;
-    return { uuid, name, email, studentNumber };
+    return { uuid, name, email, picture, studentNumber };
   }
 
   //deprecated

--- a/libs/infoteam-idp/src/types/idp.type.ts
+++ b/libs/infoteam-idp/src/types/idp.type.ts
@@ -8,7 +8,7 @@ export type IdpUserInfoResponse = {
   sub: string;
   email: string;
   name: string;
-  picture: string | null;
+  picture?: string;
   student_id?: string;
   phone_number?: string;
 };

--- a/libs/infoteam-idp/src/types/idp.type.ts
+++ b/libs/infoteam-idp/src/types/idp.type.ts
@@ -8,6 +8,7 @@ export type IdpUserInfoResponse = {
   sub: string;
   email: string;
   name: string;
+  picture: string;
   student_id?: string;
   phone_number?: string;
 };

--- a/libs/infoteam-idp/src/types/idp.type.ts
+++ b/libs/infoteam-idp/src/types/idp.type.ts
@@ -8,7 +8,7 @@ export type IdpUserInfoResponse = {
   sub: string;
   email: string;
   name: string;
-  picture: string;
+  picture: string | null;
   student_id?: string;
   phone_number?: string;
 };

--- a/libs/infoteam-idp/src/types/userInfo.type.ts
+++ b/libs/infoteam-idp/src/types/userInfo.type.ts
@@ -2,5 +2,6 @@ export type UserInfo = {
   uuid: string;
   email: string | null;
   name: string;
+  picture: string | null;
   studentNumber?: string;
 };

--- a/prisma/migrations/20251124071502_add_picture/migration.sql
+++ b/prisma/migrations/20251124071502_add_picture/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "user" ADD COLUMN     "picture" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -33,6 +33,7 @@ model User {
   uuid      String   @id @db.Uuid
   name      String
   email     String?
+  picture   String?
   createdAt DateTime @default(now()) @map("created_at")
   consent   Boolean
 


### PR DESCRIPTION
# Pull request

## 개요
db에 idp로부터 불러온 프로필 이미지 url 저장
현재 idp에서 잘못된 url이 불러와져서 fe, app에서 제대로 작동 안 할 수 있음

## PR Checklist

- [x] 환경에 따른 실행 여부를 확인하였나요?
- [x] 변경 내용에 관한 테스트를 진행하였나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 사용자 프로필에 프로필 사진(picture) 필드가 추가되었습니다.
  * 로그인 시 외부 IDP의 프로필 사진을 받아 저장합니다.
  * 사용자 정보 조회 응답에 프로필 사진이 포함되어 반환됩니다.

* **문서**
  * ER 다이어그램 및 API 응답 스펙에 프로필 사진 필드가 반영되었습니다.

* **데이터베이스**
  * 사용자 테이블에 프로필 사진 컬럼이 추가되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->