### PR TITLE
fix: health에서 groups를 비활성화

### DIFF
--- a/apps/api/src/health/health.controller.ts
+++ b/apps/api/src/health/health.controller.ts
@@ -32,7 +32,6 @@ export class HealthController {
     return this.health.check([
       () =>
         this.http.pingCheck('infoteam-idp', this.configService.IDP_BASE_URL),
-      () => this.http.pingCheck('groups', this.configService.GROUPS_URL),
       () => this.prisma.pingCheck('database', this.prismaService),
       () => this.memory.checkRSS('memory_rss', 1024 * 1024 * 150),
       () => this.redis.isHealthy('redis'),


### PR DESCRIPTION
# Pull request

## 개요
<!-- 어떤 이슈를 해결하였나요? -->
#248 

## PR Checklist

- [ ] 환경에 따른 실행 여부를 확인하였나요?
- [ ] 변경 내용에 관한 테스트를 진행하였나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **기타**
  * 헬스 체크 프로세스에서 그룹 엔드포인트 모니터링이 제거되었습니다. 인증, 데이터베이스, 메모리, Redis 관련 헬스 인디케이터는 변경되지 않았습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->