### PR TITLE
refactor: move health RSS memory limit to custom config

### DIFF
--- a/apps/api/src/health/health.controller.ts
+++ b/apps/api/src/health/health.controller.ts
@@ -15,6 +15,8 @@ import { ApiTags } from '@nestjs/swagger';
 @Controller('health')
 export class HealthController {
   private readonly logger = new Logger(HealthController.name);
+  private readonly bytesPerMb = 1024 * 1024;
+
   constructor(
     private readonly configService: CustomConfigService,
     private readonly prismaService: PrismaService,
@@ -33,7 +35,11 @@ export class HealthController {
       () =>
         this.http.pingCheck('infoteam-idp', this.configService.IDP_BASE_URL),
       () => this.prisma.pingCheck('database', this.prismaService),
-      () => this.memory.checkRSS('memory_rss', 1024 * 1024 * 150),
+      () =>
+        this.memory.checkRSS(
+          'memory_rss',
+          this.configService.HEALTH_MEMORY_RSS_LIMIT_MB * this.bytesPerMb,
+        ),
       () => this.redis.isHealthy('redis'),
     ]);
   }

--- a/libs/custom-config/src/custom-config.service.ts
+++ b/libs/custom-config/src/custom-config.service.ts
@@ -113,4 +113,8 @@ export class CustomConfigService {
   get REFRESH_TOKEN_EXPIRE(): string {
     return this.getEnvVariable('REFRESH_TOKEN_EXPIRE');
   }
+
+  get HEALTH_MEMORY_RSS_LIMIT_MB(): number {
+    return this.configService.get<number>('HEALTH_MEMORY_RSS_LIMIT_MB') ?? 200;
+  }
 }

--- a/libs/custom-config/src/env.validation.ts
+++ b/libs/custom-config/src/env.validation.ts
@@ -1,6 +1,7 @@
 import { plainToInstance } from 'class-transformer';
 import {
   IsNotEmpty,
+  Min,
   IsNumber,
   IsOptional,
   IsString,
@@ -114,6 +115,7 @@ export class EnvironmentVariables {
 
   @IsOptional()
   @IsNumber()
+  @Min(200)
   HEALTH_MEMORY_RSS_LIMIT_MB?: number;
 }
 

--- a/libs/custom-config/src/env.validation.ts
+++ b/libs/custom-config/src/env.validation.ts
@@ -1,5 +1,11 @@
 import { plainToInstance } from 'class-transformer';
-import { IsNotEmpty, IsNumber, IsString, validateSync } from 'class-validator';
+import {
+  IsNotEmpty,
+  IsNumber,
+  IsOptional,
+  IsString,
+  validateSync,
+} from 'class-validator';
 
 export class EnvironmentVariables {
   @IsString()
@@ -105,6 +111,10 @@ export class EnvironmentVariables {
   @IsString()
   @IsNotEmpty()
   REFRESH_TOKEN_EXPIRE: string;
+
+  @IsOptional()
+  @IsNumber()
+  HEALTH_MEMORY_RSS_LIMIT_MB?: number;
 }
 
 export type EnvironmentVariableKeys = keyof EnvironmentVariables;


### PR DESCRIPTION
# Pull request

## 개요
<!-- 어떤 이슈를 해결하였나요? -->

## PR Checklist

- [x] 환경에 따른 실행 여부를 확인하였나요?
- [x] 변경 내용에 관한 테스트를 진행하였나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 헬스 체크의 메모리(RSS) 임계값을 환경 변수로 설정 가능하도록 추가(기본 200MB).
* **문서/설정**
  * 새로운 환경 변수(HEALTH_MEMORY_RSS_LIMIT_MB) 지원 및 유효성 검증 추가 — 설정 없으면 기본값 사용.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->