### PR TITLE
fix: remove image in notification

### DIFF
--- a/apps/api/src/fcm/fcm.service.ts
+++ b/apps/api/src/fcm/fcm.service.ts
@@ -185,7 +185,6 @@ export class FcmService {
     const message: MulticastMessage = {
       tokens,
       notification,
-      apns: { payload: { aps: { mutableContent: true } } },
       data,
     };
 
@@ -203,7 +202,6 @@ export class FcmService {
       .map(({ token }) => token);
 
     const invalidCodes = [
-      'messaging/invalid-argument',
       'messaging/unregistered',
       'messaging/third-party-auth-error',
       'messaging/registration-token-not-registered',

--- a/apps/api/src/notice/notice.service.ts
+++ b/apps/api/src/notice/notice.service.ts
@@ -160,7 +160,6 @@ export class NoticeService {
     const notification = {
       title: notice.title,
       body: notice.content,
-      imageUrl: notice.imageUrls ? notice.imageUrls[0] : undefined,
     };
 
     await this.fcmService.postMessageWithDelay(
@@ -188,9 +187,8 @@ export class NoticeService {
     }
 
     const notification = {
-      title: '[긴급] ' + notice.title,
+      title: notice.title,
       body: notice.content,
-      imageUrl: notice.imageUrls ? notice.imageUrls[0] : undefined,
     };
 
     await this.noticeRepository


### PR DESCRIPTION
# Pull request

## 개요
<!-- 어떤 이슈를 해결하였나요? -->

## PR Checklist

- [ ] 환경에 따른 실행 여부를 확인하였나요?
- [ ] 변경 내용에 관한 테스트를 진행하였나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **변경사항**
  * 푸시 알림의 이미지 URL 필드가 제거되었습니다.
  * 알림 제목에 포함되던 긴급 표시 접두사가 제거되어, 공지사항 제목이 그대로 전달되도록 변경되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsainfoteam/ziggle-be/pull/269?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->