### PR TITLE
refactor: update getNoticeList to handle multiple pages using from operator

### DIFF
--- a/apps/crawler/src/crawler.service.ts
+++ b/apps/crawler/src/crawler.service.ts
@@ -5,6 +5,7 @@ import { load } from 'cheerio';
 import {
   catchError,
   concatMap,
+  from,
   map,
   Observable,
   throwError,
@@ -94,35 +95,39 @@ export class CrawlerService {
     createdAt: string;
     id: number;
   }> {
-    return this.httpService
-      .get(this.targetUrl, {
-        headers: {
-          'User-Agent': '',
-        },
-      })
-      .pipe(
-        timeout(60e3),
-        map((res) => load(res.data)),
-        map(($) => $('table > tbody > tr')),
-        concatMap(($) => $.toArray().map((value: any) => load(value))),
-        map(($) => {
-          return {
-            title: $('td').eq(2).text().trim(),
-            link: `${this.targetUrl}${$('td').eq(2).find('a').attr('href')}`,
-            author: $('td').eq(3).text().trim(),
-            category: $('td').eq(1).text().trim(),
-            createdAt: $('td').eq(5).text().trim(),
-          };
-        }),
-        map((meta) => ({
-          id: Number.parseInt(meta.link.split('no=')[1].split('&')[0]),
-          ...meta,
-        })),
-        catchError((err) => {
-          this.logger.error(err);
-          return throwError(() => new Error(err));
-        }),
-      );
+    return from([this.targetUrl, `${this.targetUrl}?&GotoPage=2`]).pipe(
+      concatMap((url) =>
+        this.httpService
+          .get(url, {
+            headers: {
+              'User-Agent': '',
+            },
+          })
+          .pipe(
+            timeout(60e3),
+            map((res) => load(res.data)),
+            map(($) => $('table > tbody > tr')),
+            concatMap(($) => $.toArray().map((value: any) => load(value))),
+            map(($) => {
+              return {
+                title: $('td').eq(2).text().trim(),
+                link: `${this.targetUrl}${$('td').eq(2).find('a').attr('href')}`,
+                author: $('td').eq(3).text().trim(),
+                category: $('td').eq(1).text().trim(),
+                createdAt: $('td').eq(5).text().trim(),
+              };
+            }),
+            map((meta) => ({
+              id: Number.parseInt(meta.link.split('no=')[1].split('&')[0]),
+              ...meta,
+            })),
+          ),
+      ),
+      catchError((err) => {
+        this.logger.error(err);
+        return throwError(() => new Error(err));
+      }),
+    );
   }
 
   getNoticeDetail(link: string): Observable<{


### PR DESCRIPTION
# Pull request

## 개요
<!-- 어떤 이슈를 해결하였나요? -->
크롤링을 2페이지까지 불러오도록

## PR Checklist

- [x] 환경에 따른 실행 여부를 확인하였나요?
- [x] 변경 내용에 관한 테스트를 진행하였나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 공지사항 조회 시 기본 페이지와 2페이지의 공지사항을 함께 불러오도록 개선했습니다.
  * 여러 페이지 요청 중 오류가 발생하면 전체 조회 흐름에서 일관되게 처리됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->