### PR TITLE
refactor: update CreateNoticeResDto to use string tags instead of number IDs

### DIFF
--- a/apps/api/src/notice/dto/res/createNoticeRes.dto.ts
+++ b/apps/api/src/notice/dto/res/createNoticeRes.dto.ts
@@ -5,8 +5,8 @@ import { NoticeCommonDto } from './generalNotice.dto';
 @Exclude()
 export class CreateNoticeResDto extends NoticeCommonDto {
   @Expose()
-  @ApiProperty({ type: [Number] })
-  tags: number[];
+  @ApiProperty({ type: [String] })
+  tags: string[];
 
   constructor(partial: CreateNoticeResDto) {
     super(partial);

--- a/apps/api/src/notice/notice.mapper.ts
+++ b/apps/api/src/notice/notice.mapper.ts
@@ -161,6 +161,6 @@ export const toCreateNoticeResDto = (
   const expandedNotice = toExpandedNoticeDto(notice, fileService);
   return new CreateNoticeResDto({
     ...expandedNotice,
-    tags: notice.tags.map(({ id }) => id),
+    tags: notice.tags.map(({ name }) => name),
   });
 };


### PR DESCRIPTION
# Pull request

## 개요
<!-- 어떤 이슈를 해결하였나요? -->

## PR Checklist

- [ ] 환경에 따른 실행 여부를 확인하였나요?
- [ ] 변경 내용에 관한 테스트를 진행하였나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 공지사항의 태그 정보가 숫자형 식별자 대신 태그 이름으로 제공됩니다.
  * 공지사항 응답에서 태그를 보다 쉽게 확인하고 활용할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->